### PR TITLE
Try/Except GUI import to not fail on `widget` type

### DIFF
--- a/scqubits/__init__.py
+++ b/scqubits/__init__.py
@@ -51,7 +51,13 @@ from scqubits.io_utils.fileio import read, write
 from scqubits.utils.spectrum_utils import identity_wrap
 
 # GUI
-from scqubits.ui.gui import GUI
+try:
+    from scqubits.ui.gui import GUI
+except NameError:
+    warnings.warn(
+        "scqubits: could not import GUI - consider installing ipywidgets (optional dependency)?",
+        ImportWarning,
+    )
 
 # version
 try:

--- a/scqubits/core/noise.py
+++ b/scqubits/core/noise.py
@@ -227,7 +227,7 @@ class NoisySystem(ABC):
             "grid": True,
         }
         # Do not add a ylabel if we're explicitly instructed to plot rates
-        if common_noise_options.get("get_rate", False) is False
+        if common_noise_options.get("get_rate", False) is False:
             plotting_options["ylabel"] = units.get_units_time_label()
 
         plotting_options.update(


### PR DESCRIPTION
Currently the `ui/gui.py` has functions that return type `widget.interactive`. This means if you do not have the optional `ipywidgets` installed then the type checker will throw an error when importing `import scqubits`. This PR encapsulates the import statement in a try/except to avoid the error.

Also, there is a small syntax fix to one of the `if` statements. 