### PR TITLE
Fix SciPy sparse matrix namespace deprecations

### DIFF
--- a/scqubits/core/cos2phi_qubit.py
+++ b/scqubits/core/cos2phi_qubit.py
@@ -23,8 +23,7 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from numpy import ndarray
 from scipy import sparse
-from scipy.sparse.csc import csc_matrix
-from scipy.sparse.dia import dia_matrix
+from scipy.sparse import csc_matrix, dia_matrix
 
 import scqubits.core.constants as constants
 import scqubits.core.descriptors as descriptors

--- a/scqubits/core/discretization.py
+++ b/scqubits/core/discretization.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from numpy import ndarray
 from scipy import sparse
-from scipy.sparse.dia import dia_matrix
+from scipy.sparse import dia_matrix
 
 import scqubits.core.central_dispatch as dispatch
 import scqubits.core.descriptors as descriptors

--- a/scqubits/core/noise.py
+++ b/scqubits/core/noise.py
@@ -24,7 +24,7 @@ import scipy.constants
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from numpy import ndarray
-from scipy.sparse.csc import csc_matrix
+from scipy.sparse import csc_matrix
 
 import scqubits.core.units as units
 import scqubits.settings as settings

--- a/scqubits/core/operators.py
+++ b/scqubits/core/operators.py
@@ -16,8 +16,7 @@ import numpy as np
 import scipy as sp
 
 from numpy import ndarray
-from scipy.sparse.csc import csc_matrix
-from scipy.sparse.dia import dia_matrix
+from scipy.sparse import csc_matrix, dia_matrix
 
 
 def annihilation(dimension: int) -> ndarray:

--- a/scqubits/core/zeropi.py
+++ b/scqubits/core/zeropi.py
@@ -21,8 +21,7 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from numpy import ndarray
 from scipy import sparse
-from scipy.sparse.csc import csc_matrix
-from scipy.sparse.dia import dia_matrix
+from scipy.sparse import csc_matrix, dia_matrix
 
 import scqubits.core.central_dispatch as dispatch
 import scqubits.core.constants as constants
@@ -57,7 +56,7 @@ class ZeroPi(base.QubitBaseClass, serializers.Serializable, NoisyZeroPi):
     | [2] Dempster et al., Phys. Rev. B, 90, 094518 (2014). http://doi.org/10.1103/PhysRevB.90.094518
     | [3] Groszkowski et al., New J. Phys. 20, 043053 (2018). https://doi.org/10.1088/1367-2630/aab7cd
 
-    Zero-Pi qubit without coupling to the `zeta` mode, i.e., no disorder in `EC` and 
+    Zero-Pi qubit without coupling to the `zeta` mode, i.e., no disorder in `EC` and
     `EL`, see Eq. (4) in Groszkowski et al., New J. Phys. 20, 043053 (2018),
 
     .. math::
@@ -67,7 +66,7 @@ class ZeroPi(base.QubitBaseClass, serializers.Serializable, NoisyZeroPi):
                -2E_\text{J}\cos\theta\cos(\phi-\varphi_\text{ext}/2)+E_L\phi^2\\
           &\qquad +2E_\text{J} + E_J dE_J \sin\theta\sin(\phi-\phi_\text{ext}/2).
 
-    Formulation of the Hamiltonian matrix proceeds by discretization of the `phi` 
+    Formulation of the Hamiltonian matrix proceeds by discretization of the `phi`
     variable, and using charge basis for the `theta` variable.
 
     Parameters
@@ -79,7 +78,7 @@ class ZeroPi(base.QubitBaseClass, serializers.Serializable, NoisyZeroPi):
     ECJ:
         charging energy associated with the two junctions
     EC:
-        charging energy of the large shunting capacitances; set to `None` if `ECS` is 
+        charging energy of the large shunting capacitances; set to `None` if `ECS` is
         provided instead
     dEJ:
         relative disorder in EJ, i.e., (EJ1-EJ2)/EJavg
@@ -94,7 +93,7 @@ class ZeroPi(base.QubitBaseClass, serializers.Serializable, NoisyZeroPi):
     ncut:
         charge number cutoff for `n_theta`,  `n_theta = -ncut, ..., ncut`
     ECS:
-        total charging energy including large shunting capacitances and junction 
+        total charging energy including large shunting capacitances and junction
         capacitances; may be provided instead of EC
     truncated_dim:
         desired dimension of the truncated quantum system; expected: truncated_dim > 1

--- a/scqubits/core/zeropi_full.py
+++ b/scqubits/core/zeropi_full.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from numpy import ndarray
 from scipy import sparse
-from scipy.sparse.csc import csc_matrix
+from scipy.sparse import csc_matrix
 
 import scqubits
 import scqubits.core.central_dispatch as dispatch


### PR DESCRIPTION
Uses newer `csc_matrix` and `dia_matrix` imports changed in SciPy v1.8.0, see https://github.com/scipy/scipy/commit/f84b8039ac9cc9cee1144958d05db750ac8e9dee.

I think the SciPy version should be pinned to 1.8.0 but I'm not completely sure as there seemed to be files like [hilbert_space.py](https://github.com/scqubits/scqubits/blob/0596cc68b9bb2b8724b04e6741b0822f0e5d716e/scqubits/core/hilbert_space.py#L37) that already used the newer import. Did they work with scipy 1.1.0?

Closes #123 