### PR TITLE
Bug fixes and minor changes to configure in Circuit

### DIFF
--- a/scqubits/core/circuit.py
+++ b/scqubits/core/circuit.py
@@ -1804,7 +1804,6 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
         return np.sort(evals)
 
     def _esys_calc(self, evals_count: int) -> Tuple[ndarray, ndarray]:
-        print("esys called: ", self.var_categories_list)
 
         if (
             isinstance(self, Circuit)

--- a/scqubits/core/circuit.py
+++ b/scqubits/core/circuit.py
@@ -74,7 +74,7 @@ from scqubits.utils.misc import (
     flatten_list,
     flatten_list_recursive,
     number_of_lists_in_list,
-    list_intersection
+    list_intersection,
 )
 from scqubits.utils.plot_utils import _process_options
 from scqubits.utils.spectrum_utils import (
@@ -324,7 +324,7 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
 
         # update the attribute for the current instance
         setattr(self, f"_{param_name}", value)
-        
+
         relevant_subsystem_indices = []
         # update all subsystem instances
         if self.hierarchical_diagonalization:
@@ -332,7 +332,9 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
                 if hasattr(subsys, param_name):
                     relevant_subsystem_indices.append(subsys_idx)
                     setattr(subsys, param_name, value)
-            self.build_hilbertspace(relevant_subsystem_indices=relevant_subsystem_indices)
+            self.build_hilbertspace(
+                relevant_subsystem_indices=relevant_subsystem_indices
+            )
 
     def _set_property_and_update_cutoffs(self, param_name: str, value: int) -> None:
         """
@@ -354,7 +356,9 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
                 if hasattr(subsys, param_name):
                     relevant_subsystem_indices.append(subsys_idx)
                     setattr(subsys, param_name, value)
-            self.build_hilbertspace(relevant_subsystem_indices=relevant_subsystem_indices)
+            self.build_hilbertspace(
+                relevant_subsystem_indices=relevant_subsystem_indices
+            )
 
     def _make_property(
         self, attrib_name: str, init_val: Union[int, float], property_update_type: str
@@ -610,12 +614,12 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
                 ],
             )
         )
-        
+
         self.hilbert_space = HilbertSpace(
             [self.subsystems[i] for i in range(len(self.system_hierarchy))]
         )
 
-    def generate_hilbertspace_lookup(self, subsystem_indices = None) -> None:
+    def generate_hilbertspace_lookup(self, subsystem_indices=None) -> None:
         hilbert_space = self.hilbert_space
         bare_evals = np.empty((hilbert_space.subsystem_count,), dtype=object)
         bare_evecs = np.empty((hilbert_space.subsystem_count,), dtype=object)
@@ -628,7 +632,10 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
             if subsys_index in subsystem_indices:
                 bare_esys = subsys.eigensys(evals_count=subsys.truncated_dim)
             else:
-                bare_esys = hilbert_space["bare_evals"][subsys_index][0], hilbert_space["bare_evecs"][subsys_index][0]
+                bare_esys = (
+                    hilbert_space["bare_evals"][subsys_index][0],
+                    hilbert_space["bare_evecs"][subsys_index][0],
+                )
             bare_esys_dict[subsys_index] = bare_esys
             bare_evals[subsys_index] = NamedSlotsNdarray(
                 np.asarray([bare_esys[0].tolist()]),
@@ -657,7 +664,7 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
                 return self.parent.hilbert_space["bare_evecs"][subsys_index][0]
         else:
             return self.eigensys()[1]
-    
+
     def get_subsystem_index(self, var_index: int) -> int:
         """
         Returns the subsystem index for the subsystem to which the given var_index
@@ -680,7 +687,9 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
             f"The var_index={var_index} could not be identified with any " "subsystem."
         )
 
-    def build_hilbertspace(self, relevant_subsystem_indices: Optional[List[int]]=None):
+    def build_hilbertspace(
+        self, relevant_subsystem_indices: Optional[List[int]] = None
+    ):
         """
         Builds the HilbertSpace object for the `Circuit` instance if
         `hierarchical_diagonalization` is set to true.
@@ -1350,9 +1359,7 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
             for sym_variable in periodic_vars[short_op_name]:
                 index = get_operator_number(sym_variable.name)
                 op_name = sym_variable.name + "_operator"
-                periodic_operators[op_name] = operator_func_factory(
-                    op_func, index
-                )
+                periodic_operators[op_name] = operator_func_factory(op_func, index)
 
         return {
             **periodic_operators,
@@ -1440,7 +1447,12 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
             op_in_eigenbasis=False,
             evecs=subsystem.get_eigenstates(),
         )
-        return identity_wrap(operator, subsystem, list(self.subsystems.values()), evecs=subsystem.get_eigenstates())
+        return identity_wrap(
+            operator,
+            subsystem,
+            list(self.subsystems.values()),
+            evecs=subsystem.get_eigenstates(),
+        )
 
     def get_operator_by_name(self, operator_name: str) -> qt.Qobj:
         """
@@ -1475,7 +1487,12 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
             op_in_eigenbasis=False,
             evecs=subsystem.get_eigenstates(),
         )
-        return identity_wrap(operator, subsystem, list(self.subsystems.values()), evecs=subsystem.get_eigenstates())
+        return identity_wrap(
+            operator,
+            subsystem,
+            list(self.subsystems.values()),
+            evecs=subsystem.get_eigenstates(),
+        )
 
     # #################################################################
     # ############ Functions for eigenvalues and matrices ############
@@ -1748,7 +1765,10 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
 
         else:
             bare_esys = {
-                sys_index: (self.hilbert_space["bare_evals"][sys_index][0], self.hilbert_space["bare_evecs"][sys_index][0])
+                sys_index: (
+                    self.hilbert_space["bare_evals"][sys_index][0],
+                    self.hilbert_space["bare_evecs"][sys_index][0],
+                )
                 for sys_index, sys in enumerate(self.hilbert_space.subsys_list)
             }
             hamiltonian = self.hilbert_space.hamiltonian(bare_esys=bare_esys)
@@ -2274,7 +2294,9 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
             the initial basis
 
         """
-        U_subsys = subsystem.get_eigenstates()#eigensys(evals_count=subsystem.truncated_dim)
+        U_subsys = (
+            subsystem.get_eigenstates()
+        )  # eigensys(evals_count=subsystem.truncated_dim)
         wf_sublist = list(range(len(wf_reshaped.shape)))
         U_sublist = [wf_dim, len(wf_sublist)]
         target_sublist = wf_sublist.copy()
@@ -2367,12 +2389,16 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
             intersection = list_intersection(subsys.var_categories_list, wf_var_indices)
             if len(intersection) > 0 and var_index not in intersection:
                 if subsys.hierarchical_diagonalization:
-                    wf_dim += subsys._get_var_dim_for_reshaped_wf(wf_var_indices, var_index)
+                    wf_dim += subsys._get_var_dim_for_reshaped_wf(
+                        wf_var_indices, var_index
+                    )
                 else:
                     wf_dim += len(subsys.var_categories_list)
             elif len(intersection) > 0 and var_index in intersection:
                 if subsys.hierarchical_diagonalization:
-                    wf_dim += subsys._get_var_dim_for_reshaped_wf(wf_var_indices, var_index)
+                    wf_dim += subsys._get_var_dim_for_reshaped_wf(
+                        wf_var_indices, var_index
+                    )
                 else:
                     wf_dim += subsys.var_categories_list.index(var_index)
                 break
@@ -2380,15 +2406,15 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
                 wf_dim += 1
         return wf_dim
 
-    def _dims_to_be_summed(
-        self, var_indices: List[int], num_wf_dims
-    ) -> List[int]:
+    def _dims_to_be_summed(self, var_indices: List[int], num_wf_dims) -> List[int]:
 
         all_var_indices = self.var_categories_list
         non_summed_dims = []
         for var_index in all_var_indices:
             if var_index in var_indices:
-                non_summed_dims.append(self._get_var_dim_for_reshaped_wf(var_indices, var_index))
+                non_summed_dims.append(
+                    self._get_var_dim_for_reshaped_wf(var_indices, var_index)
+                )
         return [dim for dim in range(num_wf_dims) if dim not in non_summed_dims]
 
     def generate_wf_plot_data(
@@ -2478,7 +2504,10 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
                 wf_ext_basis = self._basis_change_harm_osc_to_phi(
                     wf_ext_basis, wf_dim, var_index, grids_dict[var_index]
                 )
-            if var_index in self.var_categories["periodic"] and change_discrete_charge_to_phi:
+            if (
+                var_index in self.var_categories["periodic"]
+                and change_discrete_charge_to_phi
+            ):
                 wf_ext_basis = self._basis_change_n_to_phi(
                     wf_ext_basis, wf_dim, var_index, grids_dict[var_index]
                 )
@@ -2491,7 +2520,9 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
             )
 
         else:
-            dims_to_be_summed = self._dims_to_be_summed(var_indices, len(wf_ext_basis.shape))
+            dims_to_be_summed = self._dims_to_be_summed(
+                var_indices, len(wf_ext_basis.shape)
+            )
         wf_plot = np.sum(
             np.abs(wf_ext_basis) ** 2,
             axis=tuple(dims_to_be_summed),

--- a/scqubits/core/circuit.py
+++ b/scqubits/core/circuit.py
@@ -1562,7 +1562,6 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
         hamiltonian_LC = hamiltonian - junction_potential
 
         H_LC_str = self._get_eval_hamiltonian_string(hamiltonian_LC)
-        self._H_LC_str_harmonic = H_LC_str
 
         offset_charge_names = [
             offset_charge.name for offset_charge in self.offset_charges
@@ -1622,7 +1621,6 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
         hamiltonian_LC = hamiltonian - junction_potential
 
         H_LC_str = self._get_eval_hamiltonian_string(hamiltonian_LC)
-        self._H_LC_str_harmonic = H_LC_str
 
         replacement_dict: Dict[str, Any] = self.operators_by_name
 

--- a/scqubits/core/circuit.py
+++ b/scqubits/core/circuit.py
@@ -2876,8 +2876,8 @@ class Circuit(Subsystem):
             truncated dimension if the user wants to use this circuit instance in
             HilbertSpace, by default `None`
         """
-        warnings.warn("""Initializing Circuit instances with `from_yaml` will not be supported in future. \
-            Use `Circuit` to initialize a Circuit instance.""",
+        warnings.warn("Initializing Circuit instances with `from_yaml` will not be " 
+            "supported in future. Use `Circuit` to initialize a Circuit instance.",
             np.VisibleDeprecationWarning,
         )
         return Circuit(

--- a/scqubits/core/circuit.py
+++ b/scqubits/core/circuit.py
@@ -1334,12 +1334,16 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
         var_index: Optional[int] = None,
     ) -> qt.Qobj:
         """
-        Returns an identity wrapped operator whose size is equal to the `self.hilbertdim()`.
+        Returns an identity wrapped operator whose size is equal to the
+        `self.hilbertdim()`. Only converts operator which belongs to a specific variable
+        index. For example, operator Q_1 or cos(\theta_1). But not, Q1*Q2.
 
         Parameters
         ----------
         operator:
             operator in the form of csc_matrix, ndarray
+        var_index:
+            integer which represents which variable index the given operator belongs to
 
         Returns
         -------

--- a/scqubits/core/circuit.py
+++ b/scqubits/core/circuit.py
@@ -108,7 +108,7 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
     """
 
     # switch used in protecting the class from erroneous addition of new attributes
-    __frozen = False
+    _frozen = False
 
     def __init__(
         self,
@@ -216,10 +216,10 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
         self.normal_mode_freqs = []
 
         self._configure()
-        self.__frozen = True
+        self._frozen = True
 
     def __setattr__(self, name, value):
-        if not self.__frozen or name in dir(self):
+        if not self._frozen or name in dir(self):
             super().__setattr__(name, value)
         else:
             raise Exception("Creating new attributes is disabled.")
@@ -2781,7 +2781,7 @@ class Circuit(Subsystem):
     """
 
     # switch used in protecting the class from erroneous addition of new attributes
-    __frozen = False
+    _frozen = False
 
     def __init__(
         self,
@@ -2858,10 +2858,10 @@ class Circuit(Subsystem):
         # needs to be included to make sure that plot_evals_vs_paramvals works
         self._init_params = []
 
-        self.__frozen = True
+        self._frozen = True
 
     def __setattr__(self, name, value):
-        if not self.__frozen or name in dir(self):
+        if not self._frozen or name in dir(self):
             super().__setattr__(name, value)
         else:
             raise Exception("Creating new attributes is disabled.")
@@ -3180,7 +3180,7 @@ class Circuit(Subsystem):
         Exception
             when system_hierarchy is set and subsystem_trunc_dims is not set.
         """
-        self.__frozen = False
+        self._frozen = False
         system_hierarchy = system_hierarchy or self.system_hierarchy
         subsystem_trunc_dims = subsystem_trunc_dims or self.subsystem_trunc_dims
         closure_branches = closure_branches or self.closure_branches
@@ -3316,7 +3316,7 @@ class Circuit(Subsystem):
             self.build_hilbertspace()
         # clear unnecesary attribs
         self.clear_unnecessary_attribs()
-        self.__frozen = True
+        self._frozen = True
 
     def variable_transformation(self) -> List[sm.Equality]:
         """

--- a/scqubits/core/circuit.py
+++ b/scqubits/core/circuit.py
@@ -2879,8 +2879,8 @@ class Circuit(Subsystem):
                 if isinstance(branch_params[param], sm.Symbol):
                     branch_params[param] = branch_params[param].name
             branch_data = [
-                branch.nodes[0].id,
-                branch.nodes[1].id,
+                branch.nodes[0].index,
+                branch.nodes[1].index,
                 branch.type,
                 branch_params,
             ]
@@ -2947,7 +2947,7 @@ class Circuit(Subsystem):
         self, node_id_1: int, node_id_2: int, branch_type: str, branch_params: dict
     ):
         for branch in self.symbolic_circuit.branches:
-            branch_node_ids = [node.id for node in branch.nodes]
+            branch_node_ids = [node.index for node in branch.nodes]
             branch_params_circ = branch.parameters.copy()
             for param in branch_params_circ:
                 if isinstance(branch_params_circ[param], sm.Symbol):

--- a/scqubits/core/circuit.py
+++ b/scqubits/core/circuit.py
@@ -504,9 +504,7 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
                     subsystem_position += f"of subsystem {grandparent.get_subsystem_index(parent.var_categories_list[0])} "
                     parent = grandparent
                 raise Exception(
-                    f"The truncation index for " + 
-                    subsystem_position +
-                    f"is too big. "
+                    f"The truncation index for " + subsystem_position + f"is too big. "
                     f"It should be lower than {subsystem.hilbertdim() - 1}."
                 )
 
@@ -2859,7 +2857,7 @@ class Circuit(Subsystem):
         truncated_dim: int = None,
     ):
         """
-        Wrapper to Circuit __init__ to create a class instance. This is deprecated and 
+        Wrapper to Circuit __init__ to create a class instance. This is deprecated and
         will not be supported in the future release.
 
         Parameters
@@ -2886,7 +2884,8 @@ class Circuit(Subsystem):
             truncated dimension if the user wants to use this circuit instance in
             HilbertSpace, by default `None`
         """
-        warnings.warn("Initializing Circuit instances with `from_yaml` will not be " 
+        warnings.warn(
+            "Initializing Circuit instances with `from_yaml` will not be "
             "supported in future. Use `Circuit` to initialize a Circuit instance.",
             np.VisibleDeprecationWarning,
         )
@@ -3077,9 +3076,13 @@ class Circuit(Subsystem):
         old_system_hierarchy = self.system_hierarchy
         old_subsystem_trunc_dims = self.subsystem_trunc_dims
         old_closure_branches = self.closure_branches
-        print(old_system_hierarchy, old_subsystem_trunc_dims)
         try:
-            self._configure(transformation_matrix=transformation_matrix, system_hierarchy=system_hierarchy, subsystem_trunc_dims=subsystem_trunc_dims, closure_branches=closure_branches)
+            self._configure(
+                transformation_matrix=transformation_matrix,
+                system_hierarchy=system_hierarchy,
+                subsystem_trunc_dims=subsystem_trunc_dims,
+                closure_branches=closure_branches,
+            )
         except:
             # resetting the necessary attributes
             self.system_hierarchy = old_system_hierarchy
@@ -3087,9 +3090,16 @@ class Circuit(Subsystem):
             self.transformation_matrix = old_transformation_matrix
             self.closure_branches = old_closure_branches
             # Calling configure
-            self._configure(transformation_matrix=old_transformation_matrix, system_hierarchy=old_system_hierarchy, subsystem_trunc_dims=old_subsystem_trunc_dims, closure_branches=old_closure_branches)
-            raise Exception("Configure failed, incorrect parameters used. Please check the above exception.")
-    
+            self._configure(
+                transformation_matrix=old_transformation_matrix,
+                system_hierarchy=old_system_hierarchy,
+                subsystem_trunc_dims=old_subsystem_trunc_dims,
+                closure_branches=old_closure_branches,
+            )
+            raise Exception(
+                "Configure failed, incorrect parameters used. Please check the above exception."
+            )
+
     def _configure(
         self,
         transformation_matrix: ndarray = None,

--- a/scqubits/core/circuit.py
+++ b/scqubits/core/circuit.py
@@ -494,6 +494,7 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
 
         for subsystem_idx, subsystem in self.subsystems.items():
             if subsystem.truncated_dim >= subsystem.hilbertdim() - 1:
+                self.hierarchical_diagonalization = False
                 raise Exception(
                     f"The truncation index for subsystem {subsystem_idx} is too big. "
                     f"It should be lower than {subsystem.hilbertdim() - 1}."
@@ -2848,8 +2849,8 @@ class Circuit(Subsystem):
         truncated_dim: int = None,
     ):
         """
-        Wrapper to Circuit __init__ to create a class instance. Will be deprecated in
-        the future release.
+        Wrapper to Circuit __init__ to create a class instance. This is deprecated and 
+        will not be supported in the future release.
 
         Parameters
         ----------
@@ -2875,6 +2876,10 @@ class Circuit(Subsystem):
             truncated dimension if the user wants to use this circuit instance in
             HilbertSpace, by default `None`
         """
+        warnings.warn("""Initializing Circuit instances with `from_yaml` will not be supported in future. \
+            Use `Circuit` to initialize a Circuit instance.""",
+            np.VisibleDeprecationWarning,
+        )
         return Circuit(
             input_string=input_string,
             from_file=from_file,

--- a/scqubits/core/circuit.py
+++ b/scqubits/core/circuit.py
@@ -103,6 +103,7 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
     truncated_dim: Optional[int], optional
         sets the truncated dimension for the current subsystem, by default 10
     """
+
     # switch used in protecting the class from erroneous addition of new attributes
     __frozen = False
 
@@ -1014,7 +1015,7 @@ class Subsystem(base.QubitBaseClass, serializers.Serializable):
                 )
             if index < var_index_list[-1]:
                 identity_right = sparse.identity(
-                    np.prod(cutoff_names[var_index_list.index(index) + 1:]),
+                    np.prod(cutoff_names[var_index_list.index(index) + 1 :]),
                     format=matrix_format,
                 )
 
@@ -2722,6 +2723,7 @@ class Circuit(Subsystem):
         truncated dimension if the user wants to use this circuit instance in
         HilbertSpace, by default `None`
     """
+
     # switch used in protecting the class from erroneous addition of new attributes
     __frozen = False
 

--- a/scqubits/core/circuit_utils.py
+++ b/scqubits/core/circuit_utils.py
@@ -341,28 +341,27 @@ def example_circuit(qubit: str) -> str:
 
 
 def grid_operator_func_factory(
-    inner_op: Callable, index: int, grids_dict: Dict[int, discretization.Grid1d]
+    inner_op: Callable, index: int
 ) -> Callable:
     def operator_func(self: "Subsystem"):
         if not self.hierarchical_diagonalization:
-            return self._kron_operator(inner_op(grids_dict[index]), index)
+            return self._kron_operator(inner_op(self.grids_dict()[index]), index)
         else:
             return self.identity_wrap_for_hd(
-                inner_op(grids_dict[index]), index
+                inner_op(self.grids_dict()[index]), index
             ).data.tocsc()
 
     return operator_func
 
-
 def operator_func_factory(
-    inner_op: Callable, cutoffs_dict: dict, index: int
+    inner_op: Callable, index: int
 ) -> Callable:
     def operator_func(self):
         if not self.hierarchical_diagonalization:
-            return self._kron_operator(inner_op(cutoffs_dict[index]), index)
+            return self._kron_operator(inner_op(self.cutoffs_dict()[index]), index)
         else:
             return self.identity_wrap_for_hd(
-                inner_op(cutoffs_dict[index]), index
+                inner_op(self.cutoffs_dict()[index]), index
             ).data.tocsc()
 
     return operator_func

--- a/scqubits/core/circuit_utils.py
+++ b/scqubits/core/circuit_utils.py
@@ -340,9 +340,7 @@ def example_circuit(qubit: str) -> str:
         raise AttributeError("Qubit not available or invalid input.")
 
 
-def grid_operator_func_factory(
-    inner_op: Callable, index: int
-) -> Callable:
+def grid_operator_func_factory(inner_op: Callable, index: int) -> Callable:
     def operator_func(self: "Subsystem"):
         if not self.hierarchical_diagonalization:
             return self._kron_operator(inner_op(self.grids_dict()[index]), index)
@@ -353,9 +351,8 @@ def grid_operator_func_factory(
 
     return operator_func
 
-def operator_func_factory(
-    inner_op: Callable, index: int
-) -> Callable:
+
+def operator_func_factory(inner_op: Callable, index: int) -> Callable:
     def operator_func(self):
         if not self.hierarchical_diagonalization:
             return self._kron_operator(inner_op(self.cutoffs_dict()[index]), index)

--- a/scqubits/core/symbolic_circuit.py
+++ b/scqubits/core/symbolic_circuit.py
@@ -621,7 +621,7 @@ class SymbolicCircuit(serializers.Serializable):
                         nodes[node_id2 - 1],
                         branch_type,
                         parameters,
-                        id_str=str(len(branches))
+                        id_str=str(len(branches)),
                     )
                 )
             elif node_id2 == 0:
@@ -631,7 +631,7 @@ class SymbolicCircuit(serializers.Serializable):
                         ground_node,
                         branch_type,
                         parameters,
-                        id_str=str(len(branches))
+                        id_str=str(len(branches)),
                     )
                 )
             else:
@@ -641,7 +641,7 @@ class SymbolicCircuit(serializers.Serializable):
                         nodes[node_id2 - 1],
                         branch_type,
                         parameters,
-                        id_str=str(len(branches))
+                        id_str=str(len(branches)),
                     )
                 )
         return branches, branch_var_dict
@@ -1267,7 +1267,9 @@ class SymbolicCircuit(serializers.Serializable):
                 if self.is_grounded:
                     L_mat[branch.nodes[0].index, branch.nodes[1].index] += -inductance
                 else:
-                    L_mat[branch.nodes[0].index - 1, branch.nodes[1].index - 1] += -inductance
+                    L_mat[
+                        branch.nodes[0].index - 1, branch.nodes[1].index - 1
+                    ] += -inductance
 
         if not self.is_any_branch_parameter_symbolic() or substitute_params:
             L_mat = L_mat + L_mat.T - np.diag(L_mat.diagonal())
@@ -1333,9 +1335,9 @@ class SymbolicCircuit(serializers.Serializable):
                         capacitance * 8
                     )
                 else:
-                    C_mat[branch.nodes[0].index - 1, branch.nodes[1].index - 1] += -1 / (
-                        capacitance * 8
-                    )
+                    C_mat[
+                        branch.nodes[0].index - 1, branch.nodes[1].index - 1
+                    ] += -1 / (capacitance * 8)
 
         if not self.is_any_branch_parameter_symbolic() or substitute_params:
             C_mat = C_mat + C_mat.T - np.diag(C_mat.diagonal())
@@ -1559,7 +1561,11 @@ class SymbolicCircuit(serializers.Serializable):
         # superconducting loops would be in circ_copy.
         superconducting_loop_branches = []
         for branch_copy in circ_copy.branches:
-            superconducting_loop_branches += [branch for branch in self.branches if is_same_branch(branch, branch_copy)]
+            superconducting_loop_branches += [
+                branch
+                for branch in self.branches
+                if is_same_branch(branch, branch_copy)
+            ]
 
         return tree, superconducting_loop_branches, node_sets
 

--- a/scqubits/core/symbolic_circuit.py
+++ b/scqubits/core/symbolic_circuit.py
@@ -98,17 +98,17 @@ class Node:
         method independent_modes.
     """
 
-    def __init__(self, id: int, marker: int):
-        self.id = id
+    def __init__(self, index: int, marker: int):
+        self.index = index
         self.marker = marker
-        self._init_params = {"id": self.id, "marker": self.marker}
+        self._init_params = {"id": self.index, "marker": self.marker}
         self.branches: List[Branch] = []
 
     def __str__(self) -> str:
-        return "Node {}".format(self.id)
+        return "Node {}".format(self.index)
 
     def __repr__(self) -> str:
-        return "Node({})".format(self.id)
+        return "Node({})".format(self.index)
 
     def connected_nodes(self, branch_type: str) -> List["Node"]:
         """
@@ -125,7 +125,7 @@ class Node:
                 branch for branch in self.branches if branch.type == branch_type
             ]
         for branch in branch_list:
-            if branch.nodes[0].id == self.id:
+            if branch.nodes[0].index == self.index:
                 result.append(branch.nodes[1])
             else:
                 result.append(branch.nodes[0])
@@ -135,7 +135,7 @@ class Node:
         """
         Returns a bool if the node is a ground node. It is ground if the id is set to 0.
         """
-        return True if self.id == 0 else False
+        return True if self.index == 0 else False
 
     def __deepcopy__(self, memo):
         cls = self.__class__
@@ -174,12 +174,12 @@ class Branch:
         n_f: Node,
         branch_type: str,
         parameters: Optional[Dict[str, float]] = None,
-        id: int = None,
+        id_str: str = None,
     ):
         self.nodes = (n_i, n_f)
         self.type = branch_type
         self.parameters = parameters
-        self.id = id
+        self.id_str = id_str
         # store info of current branch inside the provided nodes
         # setting the parameters if it is provided
         if parameters is not None:
@@ -193,15 +193,15 @@ class Branch:
             "Branch "
             + self.type
             + " connecting nodes: ("
-            + str(self.nodes[0].id)
+            + str(self.nodes[0].index)
             + ","
-            + str(self.nodes[1].id)
+            + str(self.nodes[1].index)
             + "); "
             + str(self.parameters)
         )
 
     def __repr__(self) -> str:
-        return f"Branch({self.type}, {self.nodes[0].id}, {self.nodes[1].id}, id: {self.id})"
+        return f"Branch({self.type}, {self.nodes[0].index}, {self.nodes[1].index}, id_str: {self.id_str})"
 
     def set_parameters(self, parameters) -> None:
         if self.type in ["C", "L"]:
@@ -210,7 +210,7 @@ class Branch:
             self.parameters = {"EJ": parameters[0], "ECJ": parameters[1]}
 
     def node_ids(self) -> Tuple[int, int]:
-        return self.nodes[0].id, self.nodes[1].id
+        return self.nodes[0].index, self.nodes[1].index
 
     def is_connected(self, branch) -> bool:
         """Returns a boolean indicating whether the current branch is
@@ -621,7 +621,7 @@ class SymbolicCircuit(serializers.Serializable):
                         nodes[node_id2 - 1],
                         branch_type,
                         parameters,
-                        id=len(branches) +1
+                        id_str=str(len(branches))
                     )
                 )
             elif node_id2 == 0:
@@ -631,7 +631,7 @@ class SymbolicCircuit(serializers.Serializable):
                         ground_node,
                         branch_type,
                         parameters,
-                        id=len(branches) +1
+                        id_str=str(len(branches))
                     )
                 )
             else:
@@ -641,7 +641,7 @@ class SymbolicCircuit(serializers.Serializable):
                         nodes[node_id2 - 1],
                         branch_type,
                         parameters,
-                        id=len(branches) +1
+                        id_str=str(len(branches))
                     )
                 )
         return branches, branch_var_dict
@@ -1178,18 +1178,18 @@ class SymbolicCircuit(serializers.Serializable):
                 phi_ext += self.external_fluxes[index]
 
             # if loop to check for the presence of ground node
-            if jj_branch.nodes[1].id == 0:
+            if jj_branch.nodes[1].index == 0:
                 terms += -jj_branch.parameters["EJ"] * sympy.cos(
-                    -symbols(f"φ{jj_branch.nodes[0].id}") + phi_ext
+                    -symbols(f"φ{jj_branch.nodes[0].index}") + phi_ext
                 )
-            elif jj_branch.nodes[0].id == 0:
+            elif jj_branch.nodes[0].index == 0:
                 terms += -jj_branch.parameters["EJ"] * sympy.cos(
-                    symbols(f"φ{jj_branch.nodes[1].id}") + phi_ext
+                    symbols(f"φ{jj_branch.nodes[1].index}") + phi_ext
                 )
             else:
                 terms += -jj_branch.parameters["EJ"] * sympy.cos(
-                    symbols(f"φ{jj_branch.nodes[1].id}")
-                    - symbols(f"φ{jj_branch.nodes[0].id}")
+                    symbols(f"φ{jj_branch.nodes[1].index}")
+                    - symbols(f"φ{jj_branch.nodes[0].index}")
                     + phi_ext
                 )
         return terms
@@ -1205,20 +1205,20 @@ class SymbolicCircuit(serializers.Serializable):
                 phi_ext += self.external_fluxes[index]
 
             # if loop to check for the presence of ground node
-            if jj2_branch.nodes[1].id == 0:
+            if jj2_branch.nodes[1].index == 0:
                 terms += -jj2_branch.parameters["EJ"] * sympy.cos(
-                    2 * (-symbols(f"φ" + str(jj2_branch.nodes[0].id)) + phi_ext)
+                    2 * (-symbols(f"φ" + str(jj2_branch.nodes[0].index)) + phi_ext)
                 )
-            elif jj2_branch.nodes[0].id == 0:
+            elif jj2_branch.nodes[0].index == 0:
                 terms += -jj2_branch.parameters["EJ"] * sympy.cos(
-                    2 * (symbols(f"φ{jj2_branch.nodes[1].id}") + phi_ext)
+                    2 * (symbols(f"φ{jj2_branch.nodes[1].index}") + phi_ext)
                 )
             else:
                 terms += -jj2_branch.parameters["EJ"] * sympy.cos(
                     2
                     * (
-                        symbols(f"φ{jj2_branch.nodes[1].id}")
-                        - symbols(f"φ{jj2_branch.nodes[0].id}")
+                        symbols(f"φ{jj2_branch.nodes[1].index}")
+                        - symbols(f"φ{jj2_branch.nodes[0].index}")
                         + phi_ext
                     )
                 )
@@ -1265,9 +1265,9 @@ class SymbolicCircuit(serializers.Serializable):
                 if type(inductance) != float and substitute_params:
                     inductance = param_init_vals_dict[inductance]
                 if self.is_grounded:
-                    L_mat[branch.nodes[0].id, branch.nodes[1].id] += -inductance
+                    L_mat[branch.nodes[0].index, branch.nodes[1].index] += -inductance
                 else:
-                    L_mat[branch.nodes[0].id - 1, branch.nodes[1].id - 1] += -inductance
+                    L_mat[branch.nodes[0].index - 1, branch.nodes[1].index - 1] += -inductance
 
         if not self.is_any_branch_parameter_symbolic() or substitute_params:
             L_mat = L_mat + L_mat.T - np.diag(L_mat.diagonal())
@@ -1329,11 +1329,11 @@ class SymbolicCircuit(serializers.Serializable):
                 if type(capacitance) != float and substitute_params:
                     capacitance = param_init_vals_dict[capacitance]
                 if self.is_grounded:
-                    C_mat[branch.nodes[0].id, branch.nodes[1].id] += -1 / (
+                    C_mat[branch.nodes[0].index, branch.nodes[1].index] += -1 / (
                         capacitance * 8
                     )
                 else:
-                    C_mat[branch.nodes[0].id - 1, branch.nodes[1].id - 1] += -1 / (
+                    C_mat[branch.nodes[0].index - 1, branch.nodes[1].index - 1] += -1 / (
                         capacitance * 8
                     )
 
@@ -1359,25 +1359,25 @@ class SymbolicCircuit(serializers.Serializable):
         for c_branch in branches_with_capacitance:
             element_param = {"C": "EC", "JJ": "ECJ", "JJ2": "ECJ"}
 
-            if c_branch.nodes[1].id == 0:
+            if c_branch.nodes[1].index == 0:
                 terms += (
                     1
                     / (16 * c_branch.parameters[element_param[c_branch.type]])
-                    * (symbols(f"vφ{c_branch.nodes[0].id}")) ** 2
+                    * (symbols(f"vφ{c_branch.nodes[0].index}")) ** 2
                 )
-            elif c_branch.nodes[0].id == 0:
+            elif c_branch.nodes[0].index == 0:
                 terms += (
                     1
                     / (16 * c_branch.parameters[element_param[c_branch.type]])
-                    * (-symbols(f"vφ{c_branch.nodes[1].id}")) ** 2
+                    * (-symbols(f"vφ{c_branch.nodes[1].index}")) ** 2
                 )
             else:
                 terms += (
                     1
                     / (16 * c_branch.parameters[element_param[c_branch.type]])
                     * (
-                        symbols(f"vφ{c_branch.nodes[1].id}")
-                        - symbols(f"vφ{c_branch.nodes[0].id}")
+                        symbols(f"vφ{c_branch.nodes[1].index}")
+                        - symbols(f"vφ{c_branch.nodes[0].index}")
                     )
                     ** 2
                 )
@@ -1392,25 +1392,25 @@ class SymbolicCircuit(serializers.Serializable):
                 index = self.closure_branches.index(l_branch)
                 phi_ext += self.external_fluxes[index]
 
-            if l_branch.nodes[0].id == 0:
+            if l_branch.nodes[0].index == 0:
                 terms += (
                     0.5
                     * l_branch.parameters["EL"]
-                    * (symbols(f"φ{l_branch.nodes[1].id}") + phi_ext) ** 2
+                    * (symbols(f"φ{l_branch.nodes[1].index}") + phi_ext) ** 2
                 )
-            elif l_branch.nodes[1].id == 0:
+            elif l_branch.nodes[1].index == 0:
                 terms += (
                     0.5
                     * l_branch.parameters["EL"]
-                    * (-symbols(f"φ{l_branch.nodes[0].id}") + phi_ext) ** 2
+                    * (-symbols(f"φ{l_branch.nodes[0].index}") + phi_ext) ** 2
                 )
             else:
                 terms += (
                     0.5
                     * l_branch.parameters["EL"]
                     * (
-                        symbols(f"φ{l_branch.nodes[1].id}")
-                        - symbols(f"φ{l_branch.nodes[0].id}")
+                        symbols(f"φ{l_branch.nodes[1].index}")
+                        - symbols(f"φ{l_branch.nodes[0].index}")
                         + phi_ext
                     )
                     ** 2
@@ -1521,10 +1521,10 @@ class SymbolicCircuit(serializers.Serializable):
             node_set = [
                 x
                 for x in list(set(node_set))
-                if x not in [q for p in node_sets[: node_set_index + 1] for q in p]
+                if x not in flatten_list(node_sets[: node_set_index + 1])
             ]
             if node_set:
-                node_set.sort(key=lambda x: x.id)
+                node_set.sort(key=lambda node: node.index)
 
             node_sets.append(node_set)
             node_set_index += 1
@@ -1547,8 +1547,8 @@ class SymbolicCircuit(serializers.Serializable):
                         break
 
         # ************* selecting the appropriate branches from circ as from circ_copy #
-        def is_same_branch(branch_1, branch_2):
-            return branch_1.id == branch_2.id
+        def is_same_branch(branch_1: Branch, branch_2: Branch):
+            return branch_1.id_str == branch_2.id_str
 
         tree = []  # tree having branches of the current instance
         for c_branch in tree_copy:
@@ -1603,8 +1603,8 @@ class SymbolicCircuit(serializers.Serializable):
         # find out the generation number of the node in the spanning tree
         # generation number begins from 0
         for igen, nodes in enumerate(node_sets):
-            nodes_id = [node.id for node in nodes]
-            if node.id in nodes_id:
+            nodes_id = [node.index for node in nodes]
+            if node.index in nodes_id:
                 generation = igen
                 break
         # find out the path from the node to the root
@@ -1616,16 +1616,16 @@ class SymbolicCircuit(serializers.Serializable):
             # finding the parent of the current_node, and the branch that links the
             # parent and current_node
             for branch in tree:
-                nodes_id = [node.id for node in node_sets[istep]]
-                if (branch.nodes[1].id == current_node.id) and (
-                    branch.nodes[0].id in nodes_id
+                nodes_id = [node.index for node in node_sets[istep]]
+                if (branch.nodes[1].index == current_node.index) and (
+                    branch.nodes[0].index in nodes_id
                 ):
                     ancestor_nodes_list.append(branch.nodes[0])
                     branch_path_to_root.append(branch)
                     current_node = branch.nodes[0]
                     break
-                elif (branch.nodes[0].id == current_node.id) and (
-                    branch.nodes[1].id in nodes_id
+                elif (branch.nodes[0].index == current_node.index) and (
+                    branch.nodes[1].index in nodes_id
                 ):
                     ancestor_nodes_list.append(branch.nodes[1])
                     branch_path_to_root.append(branch)

--- a/scqubits/explorer/explorer_panels.py
+++ b/scqubits/explorer/explorer_panels.py
@@ -205,10 +205,8 @@ def display_cross_kerr(
     subsys2_index = sweep.get_subsys_index(subsys2)
     type_list = [type(sys) for sys in [subsys1, subsys2]]
     if type_list.count(Oscillator) == 1:
-        title = r"ac Stark: {} <-> {}".format(subsys1.id_str, subsys2.id_str)
-        ylabel = r"ac Stark shift $\chi^{{{},{}}}_l$".format(
-            subsys1_index, subsys2_index
-        )
+        title = f"ac Stark: {subsys1.id_str} + {subsys2.id_str}"
+        ylabel = f"ac Stark shift $\chi^{{{subsys1_index},{subsys2_index}}}_l$"
         level_pairs = [(1, 1), (2, 2)]
         kerr_data = sweep["chi"][subsys1_index, subsys2_index][param_slice.fixed]
         label_list = [tuple_to_short_str(pair) for pair in level_pairs]

--- a/scqubits/settings.py
+++ b/scqubits/settings.py
@@ -71,6 +71,7 @@ else:
 # use vector graphics display in jupyter
 if executed_in_ipython():
     import matplotlib_inline.backend_inline
+
     matplotlib_inline.backend_inline.set_matplotlib_formats("pdf", "svg")
 
 

--- a/scqubits/settings.py
+++ b/scqubits/settings.py
@@ -30,6 +30,7 @@ import warnings
 from typing import Any, Type, Union
 
 import matplotlib as mpl
+import matplotlib_inline.backend_inline
 import numpy as np
 
 from cycler import cycler
@@ -67,6 +68,10 @@ if executed_in_ipython():
 else:
     PROGRESSBAR_DISABLED = True
     IN_IPYTHON = False
+
+# use vector graphics display in jupyter
+if executed_in_ipython():
+    matplotlib_inline.backend_inline.set_matplotlib_formats('pdf', 'svg')
 
 
 # run ParameterSweep directly upon initialization

--- a/scqubits/settings.py
+++ b/scqubits/settings.py
@@ -71,7 +71,7 @@ else:
 
 # use vector graphics display in jupyter
 if executed_in_ipython():
-    matplotlib_inline.backend_inline.set_matplotlib_formats('pdf', 'svg')
+    matplotlib_inline.backend_inline.set_matplotlib_formats("pdf", "svg")
 
 
 # run ParameterSweep directly upon initialization

--- a/scqubits/settings.py
+++ b/scqubits/settings.py
@@ -30,7 +30,6 @@ import warnings
 from typing import Any, Type, Union
 
 import matplotlib as mpl
-import matplotlib_inline.backend_inline
 import numpy as np
 
 from cycler import cycler
@@ -71,6 +70,7 @@ else:
 
 # use vector graphics display in jupyter
 if executed_in_ipython():
+    import matplotlib_inline.backend_inline
     matplotlib_inline.backend_inline.set_matplotlib_formats("pdf", "svg")
 
 

--- a/scqubits/ui/explorer_widget.py
+++ b/scqubits/ui/explorer_widget.py
@@ -166,12 +166,8 @@ class Explorer:
 
     def build_figure_and_axes_table(self) -> Tuple[Figure, np.ndarray]:
         # the %inline and %widget backends somehow scale differently; try to compensate
-        if _HAS_WIDGET_BACKEND:
-            self.figwidth = 6.5 * 1.2
-            self.figheight = 2.75 * 1.2
-        else:
-            self.figwidth = 6.5
-            self.figheight = 2.75
+        self.figwidth = 6.4
+        self.figheight = 2.6
 
         plt.ioff()
         fig = plt.figure(figsize=(self.figwidth, self.figheight))
@@ -675,7 +671,7 @@ class Explorer:
                 nrows=nrows,
                 squeeze=False,
             )
-            self.fig.set_size_inches(1.1 * self.figwidth, self.figheight * nrows)
+            self.fig.set_size_inches(1.1 * self.figwidth, 0.9 * self.figheight * nrows)
 
         unfilled_cols_in_last_row = (self.ncols - len(panels) % self.ncols) % self.ncols
         if unfilled_cols_in_last_row != 0:


### PR DESCRIPTION
- Fixes issue 145
- Method configure, in Circuit class, now raises an exception when invalid cutoffs are used. When configure fails to reconfigure the circuit, it returns the instance to its previous state.
- Introduces the feature of 'freezing' the Circuit and Subsystem instances where the user is no longer allowed to add any extra attributes. 