### PR TITLE
changed the expression of d_hamiltonian_d_flux for tunable transmon

### DIFF
--- a/scqubits/core/transmon.py
+++ b/scqubits/core/transmon.py
@@ -711,6 +711,12 @@ class TunableTransmon(Transmon, serializers.Serializable, NoisySystem):
                 + self.d**2 * np.sin(np.pi * self.flux) ** 2
             )
             * self.cos_phi_operator()
+            - np.pi * self.EJmax * self.d 
+            / np.sqrt(
+                np.cos(np.pi * self.flux) ** 2
+                + self.d**2 * np.sin(np.pi * self.flux) ** 2
+            )
+            * self.sin_phi_operator()
         )
         return self.process_op(native_op=native, energy_esys=energy_esys)
 


### PR DESCRIPTION
Had a discussion with Peter and Jens over email and we agreed that the new expression for d_hamiltonian_d_flux is the correct one.  The old expression was obtained by taking the derivative of the Hamiltonian with respect to flux where the flux-induced shift \varphi_0 (see Eq. (2.17) of the 2007 transmon paper https://arxiv.org/pdf/cond-mat/0703002.pdf) has been shifted away. This neglected the fact that \varphi_0 depends on flux and therefore also contributes to the derivative. The new expression was obtained by taking derivative of the Hamiltonian before shifting away \varphi_0 and once an expression was obtained and we simultaneously shift away \varphi_0 from both the Hamialtonian H and d_hamiltonian_d_flux.

Also checked that the new expression reproduces the estimates of T1 due to flux bias line in the transmon paper. 