### PR TITLE
Change use of subsys_list (deprecated) to subsystem_list

### DIFF
--- a/scqubits/core/param_sweep.py
+++ b/scqubits/core/param_sweep.py
@@ -372,7 +372,7 @@ class ParameterSweepBase(ABC, SpectrumLookupMixin):
         self, subsystems: Optional[Union[QuantumSystem, List[QuantumSystem]]]
     ) -> List[QuantumSystem]:
         if subsystems is None:
-            return self.hilbertspace.subsys_list
+            return self.hilbertspace.subsystem_list
         if isinstance(subsystems, list):
             return subsystems
         if isinstance(subsystems, QuantumSystem):


### PR DESCRIPTION
Update the use in `ParameterSweepBase` of the `HilbertSpace` deprecated property `subsys_list` to `subsystem_list`.