### PR TITLE
compatability with QuTiP 5

### DIFF
--- a/scqubits/core/hilbert_space.py
+++ b/scqubits/core/hilbert_space.py
@@ -34,7 +34,7 @@ import numpy as np
 import qutip as qt
 
 from numpy import ndarray
-from qutip.qobj import Qobj
+from qutip import Qobj
 from scipy.sparse import csc_matrix, dia_matrix
 
 import scqubits.core.central_dispatch as dispatch


### PR DESCRIPTION
I am using some of the functionality associated with the pre-release of QuTiP 5, and in order to also use scqubits this small import fix is required. I have not found any other incompatabilities