### PR TITLE
correct type annotation for the __new__ method

### DIFF
--- a/scqubits/core/qubit_base.py
+++ b/scqubits/core/qubit_base.py
@@ -28,6 +28,8 @@ from typing import (
     Tuple,
     Union,
     overload,
+    TypeVar,
+    Type,
 )
 
 import matplotlib as mpl
@@ -76,6 +78,9 @@ LevelsTuple = Tuple[int, ...]
 Transition = Tuple[int, int]
 TransitionsTuple = Tuple[Transition, ...]
 
+# annotate the types will inherit from Serializable
+QubitType = TypeVar("QubitType", bound="QuantumSystem")
+
 # -Generic quantum system container and Qubit base class------------------------------
 
 
@@ -96,7 +101,7 @@ class QuantumSystem(DispatchClient, ABC):
 
     _subclasses: List[ABCMeta] = []
 
-    def __new__(cls, *args, **kwargs) -> "QuantumSystem":
+    def __new__(cls: Type[QubitType], *args, **kwargs) -> QubitType:
         QuantumSystem._quantumsystem_counter += 1
 
         if cls.__name__ not in QuantumSystem._instance_counter:

--- a/scqubits/core/qubit_base.py
+++ b/scqubits/core/qubit_base.py
@@ -79,7 +79,7 @@ Transition = Tuple[int, int]
 TransitionsTuple = Tuple[Transition, ...]
 
 # annotate the types will inherit from Serializable
-QubitType = TypeVar("QubitType", bound="QuantumSystem")
+QuantumSystemType = TypeVar("QuantumSystemType", bound="QuantumSystem")
 
 # -Generic quantum system container and Qubit base class------------------------------
 
@@ -101,7 +101,7 @@ class QuantumSystem(DispatchClient, ABC):
 
     _subclasses: List[ABCMeta] = []
 
-    def __new__(cls: Type[QubitType], *args, **kwargs) -> QubitType:
+    def __new__(cls: Type[QuantumSystemType], *args, **kwargs) -> QuantumSystemType:
         QuantumSystem._quantumsystem_counter += 1
 
         if cls.__name__ not in QuantumSystem._instance_counter:

--- a/scqubits/io_utils/fileio_serializers.py
+++ b/scqubits/io_utils/fileio_serializers.py
@@ -59,7 +59,7 @@ class Serializable(Protocol):
             SERIALIZABLE_REGISTRY[cls.__name__] = cls
 
     @classmethod
-    def deserialize(cls, io_data: "IOData") -> "Serializable":
+    def deserialize(cls: Type[SerializableType], io_data: "IOData") -> SerializableType:
         """
         Take the given IOData and return an instance of the described class,
         initialized with the data stored in io_data.

--- a/scqubits/io_utils/fileio_serializers.py
+++ b/scqubits/io_utils/fileio_serializers.py
@@ -18,7 +18,7 @@ import inspect
 from abc import ABCMeta
 from collections import OrderedDict
 from numbers import Number
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Union, TypeVar, Type
 
 import numpy as np
 
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
 
 SERIALIZABLE_REGISTRY = {}
 
+# annotate the types will inherit from Serializable
+SerializableType = TypeVar("SerializableType", bound="Serializable")
 
 @runtime_checkable
 class Serializable(Protocol):
@@ -42,7 +44,7 @@ class Serializable(Protocol):
 
     _subclasses: List[ABCMeta] = []
 
-    def __new__(cls: Any, *args, **kwargs) -> "Serializable":
+    def __new__(cls: Type[SerializableType], *args, **kwargs) -> SerializableType:
         """Modified `__new__` to set up `cls._init_params`. The latter is used to
         record which of the `__init__` parameters are to be stored/read in file IO."""
         cls._init_params = get_init_params(cls)


### PR DESCRIPTION
Depending on which class is inheriting, the `__new__` method of a base class may return a different type. Use `TypeVar` can correctly annotate this function.