### PR TITLE
Fixing compatibility issue with qutip 5.0.X in HilbertSpace.hamiltonian()

### DIFF
--- a/scqubits/core/hilbert_space.py
+++ b/scqubits/core/hilbert_space.py
@@ -830,7 +830,8 @@ class HilbertSpace(
             independent of the external parameter
         """
         bare_hamiltonian = (
-            qt.Qobj(0, dims=[self.subsystem_dims] * 2)
+            qt.Qobj(np.zeros((int(np.prod(self.subsystem_dims)), int(np.prod(self.subsystem_dims)))),
+                    dims=[self.subsystem_dims] * 2)
             if qt.__version__ >= "5.0.0"
             else qt.Qobj(0)
         )

--- a/scqubits/core/hilbert_space.py
+++ b/scqubits/core/hilbert_space.py
@@ -862,7 +862,8 @@ class HilbertSpace(
         """
         if not self.interaction_list:
             return (
-                qt.Qobj(0, dims=[self.subsystem_dims] * 2)
+                qt.Qobj(np.zeros((int(np.prod(self.subsystem_dims)), int(np.prod(self.subsystem_dims)))),
+                        dims=[self.subsystem_dims] * 2)
                 if qt.__version__ >= "5.0.0"
                 else qt.Qobj(0)
             )


### PR DESCRIPTION
The issue has already been anticipated and solved based on a pre-release of qutip 5.0.0 in #198 and #202.

However, using the latest releases of qutip 5.0.0 and 5.0.1, generating a `Qobj` through `HilbertSpace.hamiltonian()` fails during initialization of the `Qobj` in the `bare_hamiltonian()` and `interaction_hamiltonian()` function.

Minimal example:

```
tmon = scq.Transmon(EJ=1, EC=1, ng=1, ncut=10, truncated_dim=5)
hilbert_space = scq.HilbertSpace([tmon])
H = hilbert_space.hamiltonian()
```

Raises `ValueError: Provided dimensions do not match the data: (5, 5) vs (1, 1)`

The suggested fix resolves this issue for qutip 5.0.0 and 5.0.1