### PR TITLE
[Unitary Hack] code documentation (#222 fix)

### DIFF
--- a/scqubits/core/cos2phi_qubit.py
+++ b/scqubits/core/cos2phi_qubit.py
@@ -40,7 +40,7 @@ from scqubits.core.noise import NOISE_PARAMS, NoisySystem, calc_therm_ratio
 from scqubits.core.storage import WaveFunctionOnGrid
 
 
-# - Cosine-2-phi qubit noise class ------------------------------------------------------------------------------------
+# - Cosine-2-phi qubit noise class ------------------------------------------
 class NoisyCos2PhiQubit(NoisySystem, ABC):
     @abstractmethod
     def phi_1_operator(
@@ -108,7 +108,8 @@ class NoisyCos2PhiQubit(NoisySystem, ABC):
         Returns
         -------
         time or rate
-            decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate in inverse units.
+            decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate in 
+            inverse units.
         """
         if "t1_inductive" not in self.supported_noise_channels():
             raise RuntimeError(
@@ -142,6 +143,22 @@ class NoisyCos2PhiQubit(NoisySystem, ABC):
                 return Q_ind
 
         def spectral_density1(omega, T):
+            r"""
+            Calculates the first spectral density from the angular frequency 
+            and temperature.
+
+            Parameters
+            ----------
+            omega:
+                angular frequency in system units (units of frequency)
+            T:
+                temperature in Kelvin
+            
+            Returns
+            -------
+            Spectral density 
+
+            """
             therm_ratio = calc_therm_ratio(omega, T)
             s = (
                 2
@@ -159,6 +176,22 @@ class NoisyCos2PhiQubit(NoisySystem, ABC):
         noise_op1 = self.phi_1_operator()
 
         def spectral_density2(omega, T):
+            r"""
+            Calculates the second spectral density from the angular frequency 
+            and temperature.
+
+            Parameters
+            ----------
+            omega:
+                angular frequency in system units (units of frequency)
+            T:
+                temperature in Kelvin
+            
+            Returns
+            -------
+            Spectral Density
+
+            """
             therm_ratio = calc_therm_ratio(omega, T)
             s = (
                 2
@@ -261,6 +294,22 @@ class NoisyCos2PhiQubit(NoisySystem, ABC):
                 return Q_cap
 
         def spectral_density1(omega, T):
+            r"""
+            Calculates the first spectral density from the angular frequency 
+            and temperature.
+
+            Parameters
+            ----------
+            omega:
+                angular frequency in system units (units of frequency)
+            T:
+                temperature in Kelvin
+            
+            Returns
+            -------
+            Spectral density 
+            
+            """
             therm_ratio = calc_therm_ratio(omega, T)
             s1 = (
                 2
@@ -277,6 +326,22 @@ class NoisyCos2PhiQubit(NoisySystem, ABC):
             return s1
 
         def spectral_density2(omega, T):
+            r"""
+            Calculates the second spectral density from the angular frequency 
+            and temperature.
+
+            Parameters
+            ----------
+            omega:
+                angular frequency in system units (units of frequency)
+            T:
+                temperature in Kelvin
+            
+            Returns
+            -------
+            Spectral density 
+            
+            """
             therm_ratio = calc_therm_ratio(omega, T)
             s2 = (
                 2
@@ -355,7 +420,8 @@ class NoisyCos2PhiQubit(NoisySystem, ABC):
         Returns
         -------
         time or rate
-            decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate in inverse units.
+            decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate 
+            in inverse units.
 
         """
         if "t1_purcell" not in self.supported_noise_channels():
@@ -379,6 +445,22 @@ class NoisyCos2PhiQubit(NoisySystem, ABC):
                 return Q_cap
 
         def spectral_density(omega, T):
+            r"""
+            Calculates the spectral density from the angular frequency 
+            and temperature.
+
+            Parameters
+            ----------
+            omega:
+                angular frequency in system units (units of frequency)
+            T:
+                temperature in Kelvin
+            
+            Returns
+            -------
+            Spectral density 
+            
+            """
             therm_ratio = calc_therm_ratio(omega, T)
             s = (
                 2
@@ -410,7 +492,8 @@ class NoisyCos2PhiQubit(NoisySystem, ABC):
 class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQubit):
     r"""Cosine Two Phi Qubit
 
-    | [1] Smith et al., NPJ Quantum Inf. 6, 8 (2020) http://www.nature.com/articles/s41534-019-0231-2
+    | [1] Smith et al., NPJ Quantum Inf. 6, 8 (2020) 
+    http://www.nature.com/articles/s41534-019-0231-2
 
     .. math::
 
@@ -525,6 +608,43 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
 
     @staticmethod
     def default_params() -> Dict[str, Any]:
+        r"""
+        Returns the default parameters for EJ, ECJ, EL, dCJ, dL,
+        dEJ, flux, ng, ncut, zeta_cut, and phi_cut variables.
+
+        EJ:
+            Josephson energy of the two junctions
+        ECJ:
+            charging energy of the two junctions
+        EL:
+            inductive energy of the two inductors
+        EC:
+            charging energy of the shunt capacitor
+        dCJ:
+            disorder in junction charging energy
+        dL:
+            disorder in inductive energy
+        dEJ:
+            disorder in junction energy
+        flux:
+            external magnetic flux in units of one flux quantum
+        ng:
+            offset charge
+        ncut:
+            cutoff in charge basis, -ncut <= n_\theta <= ncut
+        zeta_cut:
+            number of harmonic oscillator basis states for \zeta variable
+        phi_cut:
+            number of harmonic oscillator basis states for \phi variable
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        Dictionary with arbitrary (Any) string values for the above variables. 
+        """
         return {
             "EJ": 15.0,
             "ECJ": 2.0,
@@ -542,6 +662,19 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
 
     @classmethod
     def create(cls) -> "Cos2PhiQubit":
+        r"""
+        Method to create a Cosine Two Phi Qubit.
+
+        Parameters
+        ----------
+        cls:
+            Class type of Cos2PhiQubit
+        
+        Returns
+        -------
+        Cos Two Phi Qubit
+
+        """
         init_params = cls.default_params()
         cosinetwophiqubit = cls(**init_params)
         cosinetwophiqubit.widget()
@@ -549,7 +682,18 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
 
     @classmethod
     def supported_noise_channels(cls) -> List[str]:
-        """Return a list of supported noise channels"""
+        r"""
+        Return a list of supported noise channels
+        
+        Parameters
+        ----------
+        cls:
+            Class Method Instance
+        
+        Returns
+        -------
+        List of strings
+        """
         return [
             "tphi_1_over_f_cc",
             "tphi_1_over_f_flux",
@@ -560,64 +704,180 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         ]
 
     def _dim_phi(self) -> int:
+        r"""
+        Returns Hilbert space dimension of :math:`\\phi` 
+        degree of freedom
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+
+        Returns
+        -------
+        Integer
+        
         """
-        Returns Hilbert space dimension of :math:`\\phi` degree of freedom"""
         return self.phi_cut
 
     def _dim_zeta(self) -> int:
+        r"""
+        Returns Hilbert space dimension of :math:`\\zeta` 
+        degree of freedom
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+
+        Returns
+        -------
+        Integer
+        
         """
-        Returns Hilbert space dimension of :math:`\\zeta` degree of freedom"""
         return self.zeta_cut
 
     def _dim_theta(self) -> int:
+        r"""
+        Returns Hilbert space dimension of :math:`\\theta` degree of freedom
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+
+        Returns
+        -------
+        Integer
+        
         """
-        Returns Hilbert space dimension of :math:`\\theta` degree of freedom"""
         return 2 * self.ncut + 1
 
     def hilbertdim(self) -> int:
+        r"""
+        Returns total Hilbert space dimension
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
+        Returns
+        -------
+        Integer
+
         """
-        Returns total Hilbert space dimension"""
         return self._dim_phi() * self._dim_zeta() * self._dim_theta()
 
     def _disordered_el(self) -> float:
-        """
+        r"""
+        Returns inductive energy renormalized by with disorder.
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
         Returns
         -------
-            inductive energy renormalized by with disorder"""
+        Float
+        """
         return self.EL / (1 - self.dL**2)
 
     def _disordered_ecj(self) -> float:
-        """
+        r"""
+        Returns junction capacitance energy renormalized by with disorder.
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+
         Returns
         -------
-            junction capacitance energy renormalized by with disorder"""
+        Float
+
+        """
         return self.ECJ / (1 - self.dCJ**2)
 
     def phi_osc(self) -> float:
+        r"""
+        Returns oscillator strength of :math:`\\phi` degree of freedom.
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
+        Returns
+        -------
+        Float
+        
         """
-        Returns oscillator strength of :math:`\\phi` degree of freedom"""
         return (2 * self._disordered_ecj() / self._disordered_el()) ** 0.25
 
     def zeta_osc(self) -> float:
+        r"""
+        Returns oscillator strength of :math:`\\zeta` degree of freedom.
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
+        Returns
+        -------
+        Float
+        
         """
-        Returns oscillator strength of :math:`\\zeta` degree of freedom"""
         return (4 * self.EC / self._disordered_el()) ** 0.25
 
     def phi_plasma(self) -> float:
+        r"""
+        Returns plasma oscillation frequency of :math:`\\phi` degree of freedom.
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
+        Returns
+        -------
+        Float
+        
         """
-        Returns plasma oscillation frequency of :math:`\\phi` degree of freedom"""
         return math.sqrt(8.0 * self._disordered_el() * self._disordered_ecj())
 
     def zeta_plasma(self) -> float:
+        r"""
+        Returns plasma oscillation frequency of :math:`\\zeta` degree of freedom.
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
+        Returns
+        -------
+        Float
+
         """
-        Returns plasma oscillation frequency of :math:`\\zeta` degree of freedom"""
         return math.sqrt(16.0 * self.EC * self._disordered_el())
 
     def _phi_operator(self) -> csc_matrix:
-        """
+        r"""
+        Returns `phi` operator in the harmonic oscillator basis.
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+
         Returns
         -------
-            `phi` operator in the harmonic oscillator basis"""
+        Compressed Sparse Column Matrix
+
+        """
         dimension = self._dim_phi()
         return (
             (op.creation_sparse(dimension) + op.annihilation_sparse(dimension))
@@ -635,17 +895,21 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         ----------
         energy_esys:
             If `False` (default), returns :math:`\phi` operator in the native basis.
-            If `True`, the energy eigenspectrum is computed, returns :math:`\phi` operator in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns :math:`\phi` operator in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `True`, the energy eigenspectrum is computed, returns :math:`\phi` operator in 
+            the energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and 
+            energy eigenvectors), returns :math:`\phi` operator in the energy eigenbasis, and does 
+            not have to recalculate eigenspectrum.
 
         Returns
         -------
             :math:`\phi` operator in chosen basis. If native basis chosen, operator
             returned as a csc_matrix. If the eigenenergy basis is chosen,
             unless energy_esys is specified, :math:`\phi` operator has dimensions of truncated_dim
-            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is chosen, :math:`\phi`
-            operator has dimensions of m x m, for m given eigenvectors, and is returned as an ndarray.
+            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is 
+            chosen, :math:`\phi` operator has dimensions of m x m, for m given eigenvectors, 
+            and is returned as an ndarray.
+        
         """
         native = self._kron3(
             self._phi_operator(), self._identity_zeta(), self._identity_theta()
@@ -654,9 +918,18 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
 
     def _n_phi_operator(self) -> csc_matrix:
         r"""
+        Returns `n_\phi` operator in the harmonic oscillator basis.
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
         Returns
         -------
-            `n_\phi` operator in the harmonic oscillator basis"""
+        Compressed Sparse Column Matrix
+
+        """
         dimension = self._dim_phi()
         return (
             1j
@@ -675,17 +948,21 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         ----------
         energy_esys:
             If `False` (default), returns :math:`n_\phi` operator in the native basis.
-            If `True`, the energy eigenspectrum is computed, returns :math:`n_\phi` operator in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns :math:`n_\phi` operator in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `True`, the energy eigenspectrum is computed, returns :math:`n_\phi` operator 
+            in the energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues 
+            and energy eigenvectors), returns :math:`n_\phi` operator in the energy eigenbasis, 
+            and does not have to recalculate eigenspectrum.
 
         Returns
         -------
             :math:`n_\phi` operator in chosen basis. If native basis chosen, operator
             returned as a csc_matrix. If the eigenenergy basis is chosen,
             unless energy_esys is specified, :math:`n_\phi` operator has dimensions of truncated_dim
-            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is chosen, :math:`n_\phi`
-            operator has dimensions of m x m, for m given eigenvectors, and is returned as an ndarray :math:`\zeta`.
+            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is 
+            chosen, :math:`n_\phi` operator has dimensions of m x m, for m given eigenvectors, 
+            and is returned as an ndarray :math:`\zeta`.
+
         """
         native = self._kron3(
             self._n_phi_operator(), self._identity_zeta(), self._identity_theta()
@@ -693,10 +970,19 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         return self.process_op(native_op=native, energy_esys=energy_esys)
 
     def _zeta_operator(self) -> csc_matrix:
-        """
+        r"""
+        Returns `zeta` operator in the harmonic oscillator basis.
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
         Returns
         -------
-            `zeta` operator in the harmonic oscillator basis"""
+        Compressed Sparse Column Matrix
+
+        """
         dimension = self._dim_zeta()
         return (
             (op.creation_sparse(dimension) + op.annihilation_sparse(dimension))
@@ -714,17 +1000,20 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         ----------
         energy_esys:
             If `False` (default), returns :math:`\zeta` operator in the native basis.
-            If `True`, the energy eigenspectrum is computed, returns :math:`\zeta`  operator in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns :math:`\zeta`  operator in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `True`, the energy eigenspectrum is computed, returns :math:`\zeta`  operator 
+            in the energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues 
+            and energy eigenvectors), returns :math:`\zeta`  operator in the energy eigenbasis, 
+            and does not have to recalculate eigenspectrum.
 
         Returns
         -------
             :math:`\zeta`  operator in chosen basis. If native basis chosen, operator
             returned as a csc_matrix. If the eigenenergy basis is chosen,
             unless energy_esys is specified, :math:`\zeta`  operator has dimensions of truncated_dim
-            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is chosen, :math:`\zeta`
-            operator has dimensions of m x m, for m given eigenvectors, and is returned as an ndarray.
+            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is 
+            chosen, :math:`\zeta` operator has dimensions of m x m, for m given eigenvectors, 
+            and is returned as an ndarray.
         """
         native = self._kron3(
             self._identity_phi(), self._zeta_operator(), self._identity_theta()
@@ -733,9 +1022,18 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
 
     def _n_zeta_operator(self) -> csc_matrix:
         r"""
+        Returns `n_\zeta` operator in the harmonic oscillator basis.
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
         Returns
         -------
-            `n_\zeta` operator in the harmonic oscillator basis"""
+        Compressed Sparse Column Matrix
+
+        """
         dimension = self._dim_zeta()
         return (
             1j
@@ -753,17 +1051,21 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         ----------
         energy_esys:
             If `False` (default), returns :math:`n_\zeta` operator in the native basis.
-            If `True`, the energy eigenspectrum is computed, returns :math:`n_\zeta`  operator in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns :math:`n_\zeta`  operator in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `True`, the energy eigenspectrum is computed, returns :math:`n_\zeta`  operator 
+            in the energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues 
+            and energy eigenvectors), returns :math:`n_\zeta`  operator in the energy eigenbasis, 
+            and does not have to recalculate eigenspectrum.
 
         Returns
         -------
             :math:`n_\zeta`  operator in chosen basis. If native basis chosen, operator
             returned as a csc_matrix. If the eigenenergy basis is chosen,
-            unless energy_esys is specified, :math:`n_\zeta`  operator has dimensions of truncated_dim
-            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is chosen, :math:`n_\zeta`
-            operator has dimensions of m x m, for m given eigenvectors, and is returned as an ndarray.
+            unless energy_esys is specified, :math:`n_\zeta`  operator has dimensions of 
+            truncated_dim x truncated_dim, and is returned as an ndarray. Otherwise, if 
+            eigenenergy basis is chosen, :math:`n_\zeta` operator has dimensions of m x m, 
+            for m given eigenvectors, and is returned as an ndarray.
+        
         """
         native = self._kron3(
             self._identity_phi(), self._n_zeta_operator(), self._identity_theta()
@@ -771,36 +1073,72 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         return self.process_op(native_op=native, energy_esys=energy_esys)
 
     def _exp_i_phi_operator(self) -> csc_matrix:
-        """
+        r"""
+        Returns `e^{i*phi}` operator in the  harmonic oscillator basis
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
         Returns
         -------
-            `e^{i*phi}` operator in the  harmonic oscillator basis"""
+        Compressed Sparse Column Matrix
+
+        """
         exponent = 1j * self._phi_operator()
         return sp.sparse.linalg.expm(exponent)
 
     def _cos_phi_operator(self) -> csc_matrix:
-        """
+        r"""
+        Returns `cos phi` operator in the harmonic oscillator basis.
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
         Returns
         -------
-            `cos phi` operator in the harmonic oscillator basis"""
+        Compressed Sparse Column Matrix
+            
+        """
         cos_phi_op = 0.5 * self._exp_i_phi_operator()
         cos_phi_op += cos_phi_op.conj().T
         return cos_phi_op
 
     def _sin_phi_operator(self) -> csc_matrix:
-        """
+        r"""
+        Returns `sin phi/2` operator in the LC harmonic oscillator basis.
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
         Returns
         -------
-            `sin phi/2` operator in the LC harmonic oscillator basis"""
+        Compressed Sparse Column Matrix
+        
+        """
         sin_phi_op = -1j * 0.5 * self._exp_i_phi_operator()
         sin_phi_op += sin_phi_op.conj().T
         return sin_phi_op
 
     def _n_theta_operator(self) -> csc_matrix:
-        """
+        r"""
+        Returns `n_theta` operator in the charge basis.
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
         Returns
         -------
-            `n_theta` operator in the charge basis"""
+        Compressed Sparse Column Matrix
+        
+        """
         diag_elements = np.arange(-self.ncut, self.ncut + 1)
         return dia_matrix(
             (diag_elements, [0]), shape=(self._dim_theta(), self._dim_theta())
@@ -816,17 +1154,21 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         ----------
         energy_esys:
             If `False` (default), returns :math:`n_\theta` operator in the charge basis.
-            If `True`, the energy eigenspectrum is computed, returns :math:`n_\theta`  operator in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns :math:`n_\theta`  operator in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `True`, the energy eigenspectrum is computed, returns :math:`n_\theta`  
+            operator in the energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues 
+            and energy eigenvectors), returns :math:`n_\theta`  operator in the energy eigenbasis, 
+            and does not have to recalculate eigenspectrum.
 
         Returns
         -------
             :math:`n_\theta`  operator in chosen basis. If charge basis chosen, operator
             returned as a csc_matrix. If the eigenenergy basis is chosen,
-            unless energy_esys is specified, :math:`n_\theta`  operator has dimensions of truncated_dim
-            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is chosen, :math:`n_\theta`
-            operator has dimensions of m x m, for m given eigenvectors, and is returned as an ndarray.
+            unless energy_esys is specified, :math:`n_\theta`  operator has dimensions of 
+            truncated_dim x truncated_dim, and is returned as an ndarray. Otherwise, if 
+            eigenenergy basis is chosen, :math:`n_\theta` operator has dimensions of m x m, 
+            for m given eigenvectors, and is returned as an ndarray.
+        
         """
         native = self._kron3(
             self._identity_phi(), self._identity_zeta(), self._n_theta_operator()
@@ -834,7 +1176,19 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         return self.process_op(native_op=native, energy_esys=energy_esys)
 
     def _cos_theta_operator(self) -> csc_matrix:
-        r"""Returns operator :math:`\cos \theta` in the charge basis"""
+        r"""
+        Returns operator :math:`\cos \theta` in the charge basis
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
+        Returns
+        -------
+        Compressed Sparse Column Matrix
+        
+        """
         cos_op = (
             0.5
             * sparse.dia_matrix(
@@ -852,7 +1206,19 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         return cos_op
 
     def _sin_theta_operator(self) -> csc_matrix:
-        r"""Returns operator :math:`\sin \theta` in the charge basis"""
+        r"""
+        Returns operator :math:`\sin \theta` in the charge basis.
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
+        Returns
+        -------
+        Compressed Sparse Column Matrix
+        
+        """
         sin_op = (
             0.5
             * sparse.dia_matrix(
@@ -870,34 +1236,88 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         return sin_op * (-1j)
 
     def _kron3(self, mat1, mat2, mat3) -> csc_matrix:
-        """
-        Returns Kronecker product of three matrices
+        r"""
+        Returns Kronecker product of three matrices.
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
+        Returns
+        -------
+        Compressed Sparse Column Matrix
+        
         """
         return sparse.kron(sparse.kron(mat1, mat2), mat3)
 
     def _identity_phi(self) -> csc_matrix:
-        """
-        Returns Identity operator acting only on the :math:`\\phi` Hilbert subspace.
+        r"""
+        Returns Identity operator acting only on the :math:`\\phi` 
+        Hilbert subspace.
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
+        Returns
+        -------
+        Compressed Sparse Column Matrix
+        
         """
         dimension = self._dim_phi()
         return sparse.eye(dimension)
 
     def _identity_zeta(self) -> csc_matrix:
         r"""
-        Returns Identity operator acting only on the :math:`\zeta` Hilbert subspace.
+        Returns Identity operator acting only on the :math:`\zeta` 
+        Hilbert subspace.
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
+        Returns
+        -------
+        Compressed Sparse Column Matrix
+        
         """
         dimension = self._dim_zeta()
         return sparse.eye(dimension)
 
     def _identity_theta(self) -> csc_matrix:
-        """
-        Returns Identity operator acting only on the :math:`\theta` Hilbert subspace.
+        r"""
+        Returns Identity operator acting only on the :math:`\theta` 
+        Hilbert subspace.
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
+        Returns
+        -------
+        Compressed Sparse Column Matrix
+        
         """
         dimension = self._dim_theta()
         return sparse.eye(dimension)
 
     def total_identity(self) -> csc_matrix:
-        """Returns Identity operator acting on the total Hilbert space."""
+        r"""Returns Identity operator acting on the total Hilbert space.
+        
+        Parameters
+        ----------
+        self:
+            Method Instance
+        
+        Returns
+        -------
+        Compressed Sparse Column Matrix
+
+        """
         return self._kron3(
             self._identity_phi(), self._identity_zeta(), self._identity_theta()
         )
@@ -905,24 +1325,28 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
     def hamiltonian(
         self, energy_esys: Union[bool, Tuple[ndarray, ndarray]] = False
     ) -> csc_matrix:
-        """Returns Hamiltonian in basis obtained by employing harmonic basis for
+        r"""
+        Returns Hamiltonian in basis obtained by employing harmonic basis for
         :math:`\\phi, \\zeta` and charge basis for :math:`\\theta` or in the eigenenerg basis.
 
         Parameters
         ----------
         energy_esys:
-            If `False` (default), returns Hamiltonian in basis obtained by employing harmonic basis for
-            :math:`\\phi, \\zeta` and charge basis for :math:`\\theta`.
-            If `True`, the energy eigenspectrum is computed, returns Hamiltonian in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns Hamiltonian in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `False` (default), returns Hamiltonian in basis obtained by employing harmonic 
+            basis for :math:`\\phi, \\zeta` and charge basis for :math:`\\theta`.
+            If `True`, the energy eigenspectrum is computed, returns Hamiltonian in the 
+            energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and 
+            energy eigenvectors), returns Hamiltonian in the energy eigenbasis, and does not have 
+            to recalculate eigenspectrum.
 
         Returns
         -------
             Hamiltonian in chosen basis as csc_matrix. If the eigenenergy basis is chosen,
             unless `energy_esys` is specified, the Hamiltonian has dimensions of `truncated_dim`
-            x `truncated_dim`. Otherwise, if eigenenergy basis is chosen, Hamiltonian has dimensions of m x m,
-            for m given eigenvectors.
+            x `truncated_dim`. Otherwise, if eigenenergy basis is chosen, Hamiltonian has 
+            dimensions of m x m, for m given eigenvectors.
+        
         """
         phi_osc_mat = self._kron3(
             op.number_sparse(self._dim_phi(), self.phi_plasma()),
@@ -1006,6 +1430,21 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         )
 
     def _evals_calc(self, evals_count) -> ndarray:
+        r"""
+        Evaluvates the hamiltonian, and returns the safe eigensvalues.
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+        evals_count:
+            number of eigenvalues
+        
+        Returns
+        -------
+        Sorted list of eigenvalues
+        
+        """
         hamiltonian_mat = self.hamiltonian()
         evals = utils.eigsh_safe(
             hamiltonian_mat,
@@ -1017,6 +1456,22 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         return np.sort(evals)
 
     def _esys_calc(self, evals_count) -> Tuple[ndarray, ndarray]:
+        r"""
+        Evaluvates the Hamiltonian and returns the eigenvalues and
+        eigenvectors.
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+        evals_count:
+            number of eigenvalues
+        
+        Returns
+        -------
+        Eigenvalues, Eigenvectors
+
+        """
         hamiltonian_mat = self.hamiltonian()
         evals, evecs = utils.eigsh_safe(
             hamiltonian_mat,
@@ -1029,7 +1484,7 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         return evals, evecs
 
     def potential(self, phi, zeta, theta) -> float:
-        """
+        r"""
         Returns full potential evaluated at :math:`\\phi, \\zeta, \\theta`
 
         Parameters
@@ -1040,6 +1495,11 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
             float value of the phase variable `zeta`
         theta: float or ndarray
             float value of the phase variable `theta`
+
+        Returns
+        -------
+        Float
+
         """
         return (
             self._disordered_el() * (phi * phi)
@@ -1049,14 +1509,31 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         )
 
     def reduced_potential(self, phi, theta) -> float:
-        """Returns reduced potential by setting :math:`zeta = 0`"""
+        r"""
+        Returns reduced potential by setting :math:`zeta = 0`.
+
+        Parameters
+        ----------
+        self:
+            Method Instance
+        phi: float or ndarray
+            float value of variable `phi`
+        theta: float or ndarray
+            float value of variable `theta`
+
+        Returns
+        -------
+        Float
+
+        """
         return self.potential(phi, 0, theta)
 
     def plot_potential(
         self, phi_grid=None, theta_grid=None, contour_vals=None, **kwargs
     ) -> Tuple[Figure, Axes]:
-        """
-        Draw contour plot of the potential energy in :math:`\\theta, \\phi` basis, at :math:`\\zeta = 0`
+        r"""
+        Draw contour plot of the potential energy in :math:`\\theta, \\phi` basis, 
+        at :math:`\\zeta = 0`.
 
         Parameters
         ----------
@@ -1068,6 +1545,11 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         contour_vals: list, optional
         **kwargs:
             plotting parameters
+        
+        Returns
+        -------
+        Figure, Axes
+
         """
         phi_grid = phi_grid or self._default_phi_grid
         theta_grid = theta_grid or self._default_theta_grid
@@ -1087,7 +1569,7 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
     def wavefunction(
         self, esys=None, which=0, phi_grid=None, zeta_grid=None, theta_grid=None
     ) -> WaveFunctionOnGrid:
-        """
+        r"""
         Return a 3D wave function in :math:`\\phi, \\zeta, \\theta` basis
 
         Parameters
@@ -1104,6 +1586,11 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         theta_grid: Grid1d, option
             used for setting a custom grid for theta; if None use
             self._default_theta_grid
+        
+        Returns
+        -------
+        WaveFunctionOnGrid:
+            Wave Function Amplitudes
         """
         evals_count = max(which + 1, 3)
         if esys is None:
@@ -1170,7 +1657,7 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         zero_calibrate=True,
         **kwargs
     ) -> Tuple[Figure, Axes]:
-        """
+        r"""
         Plots a 2D wave function in :math:`\\theta, \\phi` basis, at :math:`\\zeta = 0`
 
         Parameters
@@ -1187,9 +1674,14 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
         mode: str, optional
             choices as specified in `constants.MODE_FUNC_DICT` (default value = 'abs_sqr')
         zero_calibrate: bool, optional
-            if True, colors are adjusted to use zero wavefunction amplitude as the neutral color in the palette
+            if True, colors are adjusted to use zero wavefunction amplitude as the neutral 
+            color in the palette
         **kwargs:
             plot options
+
+        Returns
+        -------
+        Figure, Axes
 
         """
         phi_grid = phi_grid or self._default_phi_grid
@@ -1231,24 +1723,29 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
     def phi_1_operator(
         self, energy_esys: Union[bool, Tuple[ndarray, ndarray]] = False
     ) -> Union[ndarray, csc_matrix]:
-        """
-        Returns operator representing the phase across inductor 1 in harmonic oscillator or eigenenergy basis.
+        r"""
+        Returns operator representing the phase across inductor 1 in harmonic 
+        oscillator or eigenenergy basis.
 
         Parameters
         ----------
         energy_esys:
             If `False` (default), returns operator in the harmonic oscillator basis.
-            If `True`, the energy eigenspectrum is computed, returns operator in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns operator in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `True`, the energy eigenspectrum is computed, returns operator in the 
+            energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues 
+            and energy eigenvectors), returns operator in the energy eigenbasis, and does not 
+            have to recalculate eigenspectrum.
 
         Returns
         -------
             Operator in chosen basis. If harmonic oscillator basis chosen, operator
             returned as a csc_matrix. If the eigenenergy basis is chosen,
             unless `energy_esys` is specified, operator has dimensions of `truncated_dim`
-            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is chosen,
-            operator has dimensions of m x m, for m given eigenvectors, and is returned as an ndarray.
+            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy 
+            basis is chosen, operator has dimensions of m x m, for m given eigenvectors, 
+            and is returned as an ndarray.
+        
         """
         native = self.zeta_operator() - self.phi_operator()
         return self.process_op(native_op=native, energy_esys=energy_esys)
@@ -1256,24 +1753,29 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
     def phi_2_operator(
         self, energy_esys: Union[bool, Tuple[ndarray, ndarray]] = False
     ) -> Union[ndarray, csc_matrix]:
-        """
-        Returns operator representing the phase across inductor 2 in harmonic oscillator or eigenenergy basis.
+        r"""
+        Returns operator representing the phase across inductor 2 in harmonic 
+        oscillator or eigenenergy basis.
 
         Parameters
         ----------
         energy_esys:
             If `False` (default), returns operator in the harmonic oscillator basis.
-            If `True`, the energy eigenspectrum is computed, returns operator in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns operator in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `True`, the energy eigenspectrum is computed, returns operator in the 
+            energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues 
+            and energy eigenvectors), returns operator in the energy eigenbasis, and does not 
+            have to recalculate eigenspectrum.
 
         Returns
         -------
             Operator in chosen basis. If harmonic oscillator basis chosen, operator
             returned as a csc_matrix. If the eigenenergy basis is chosen,
             unless `energy_esys` is specified, operator has dimensions of `truncated_dim`
-            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is chosen,
-            operator has dimensions of m x m, for m given eigenvectors, and is returned as an ndarray.
+            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy 
+            basis is chosen, operator has dimensions of m x m, for m given eigenvectors, 
+            and is returned as an ndarray.
+
         """
         native = -self.zeta_operator() - self.phi_operator()
         return self.process_op(native_op=native, energy_esys=energy_esys)
@@ -1281,24 +1783,29 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
     def n_1_operator(
         self, energy_esys: Union[bool, Tuple[ndarray, ndarray]] = False
     ) -> Union[ndarray, csc_matrix]:
-        """
-        Returns operator representing the charge difference across junction 1 in native or eigenenergy basis.
+        r"""
+        Returns operator representing the charge difference across junction 1 in native 
+        or eigenenergy basis.
 
         Parameters
         ----------
         energy_esys:
             If `False` (default), returns operator in the harmonic oscillator basis.
-            If `True`, the energy eigenspectrum is computed, returns operator in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns operator in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `True`, the energy eigenspectrum is computed, returns operator in the 
+            energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues 
+            and energy eigenvectors), returns operator in the energy eigenbasis, and does not 
+            have to recalculate eigenspectrum.
 
         Returns
         -------
-            Operator in chosen basis. If native basis chosen, operator
+            Operator in chosen basis. If harmonic oscillator basis chosen, operator
             returned as a csc_matrix. If the eigenenergy basis is chosen,
             unless `energy_esys` is specified, operator has dimensions of `truncated_dim`
-            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is chosen,
-            operator has dimensions of m x m, for m given eigenvectors, and is returned as an ndarray.
+            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy 
+            basis is chosen, operator has dimensions of m x m, for m given eigenvectors, 
+            and is returned as an ndarray.
+
         """
         native = 0.5 * self.n_phi_operator() + 0.5 * (
             self.n_theta_operator() - self.n_zeta_operator()
@@ -1308,24 +1815,29 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
     def n_2_operator(
         self, energy_esys: Union[bool, Tuple[ndarray, ndarray]] = False
     ) -> Union[ndarray, csc_matrix]:
-        """
-        Returns operator representing the charge difference across junction 2 in native or eigenenergy basis.
+        r"""
+        Returns operator representing the charge difference across junction 2 in native 
+        or eigenenergy basis.
 
         Parameters
         ----------
         energy_esys:
             If `False` (default), returns operator in the harmonic oscillator basis.
-            If `True`, the energy eigenspectrum is computed, returns operator in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns operator in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `True`, the energy eigenspectrum is computed, returns operator in the 
+            energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues 
+            and energy eigenvectors), returns operator in the energy eigenbasis, and does not 
+            have to recalculate eigenspectrum.
 
         Returns
         -------
-            Operator in chosen basis. If native basis chosen, operator
+            Operator in chosen basis. If harmonic oscillator basis chosen, operator
             returned as a csc_matrix. If the eigenenergy basis is chosen,
             unless `energy_esys` is specified, operator has dimensions of `truncated_dim`
-            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is chosen,
-            operator has dimensions of m x m, for m given eigenvectors, and is returned as an ndarray.
+            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy 
+            basis is chosen, operator has dimensions of m x m, for m given eigenvectors, 
+            and is returned as an ndarray.
+
         """
         native = 0.5 * self.n_phi_operator() - 0.5 * (
             self.n_theta_operator() - self.n_zeta_operator()
@@ -1335,25 +1847,29 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
     def d_hamiltonian_d_flux(
         self, energy_esys: Union[bool, Tuple[ndarray, ndarray]] = False
     ) -> Union[ndarray, csc_matrix]:
-        """
+        r"""
         Returns operator representing a derivative of the Hamiltonian with respect to
         flux in the native or eigenenergy basis.
 
         Parameters
         ----------
         energy_esys:
-            If `False` (default), returns operator in the native basis.
-            If `True`, the energy eigenspectrum is computed, returns operator in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns operator in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `False` (default), returns operator in the harmonic oscillator basis.
+            If `True`, the energy eigenspectrum is computed, returns operator in the 
+            energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues 
+            and energy eigenvectors), returns operator in the energy eigenbasis, and does not 
+            have to recalculate eigenspectrum.
 
         Returns
         -------
-            Operator in chosen basis. If native basis chosen, operator
+            Operator in chosen basis. If harmonic oscillator basis chosen, operator
             returned as a csc_matrix. If the eigenenergy basis is chosen,
             unless `energy_esys` is specified, operator has dimensions of `truncated_dim`
-            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is chosen,
-            operator has dimensions of m x m, for m given eigenvectors, and is returned as an ndarray.
+            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy 
+            basis is chosen, operator has dimensions of m x m, for m given eigenvectors, 
+            and is returned as an ndarray.
+
         """
         phi_flux_term = self._sin_phi_operator() * np.cos(
             self.flux * np.pi
@@ -1385,25 +1901,29 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
     def d_hamiltonian_d_EJ(
         self, energy_esys: Union[bool, Tuple[ndarray, ndarray]] = False
     ) -> Union[ndarray, csc_matrix]:
-        """
+        r"""
         Returns operator representing a derivative of the Hamiltonian with respect to
         EJ in the native or eigenenergy basis.
 
         Parameters
         ----------
         energy_esys:
-            If `False` (default), returns operator in the native basis.
-            If `True`, the energy eigenspectrum is computed, returns operator in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns operator in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `False` (default), returns operator in the harmonic oscillator basis.
+            If `True`, the energy eigenspectrum is computed, returns operator in the 
+            energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues 
+            and energy eigenvectors), returns operator in the energy eigenbasis, and does not 
+            have to recalculate eigenspectrum.
 
         Returns
         -------
-            Operator in chosen basis. If native basis chosen, operator
+            Operator in chosen basis. If harmonic oscillator basis chosen, operator
             returned as a csc_matrix. If the eigenenergy basis is chosen,
             unless `energy_esys` is specified, operator has dimensions of `truncated_dim`
-            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is chosen,
-            operator has dimensions of m x m, for m given eigenvectors, and is returned as an ndarray.
+            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy 
+            basis is chosen, operator has dimensions of m x m, for m given eigenvectors, 
+            and is returned as an ndarray.
+
         """
         phi_flux_term = self._cos_phi_operator() * np.cos(
             self.flux * np.pi
@@ -1428,25 +1948,29 @@ class Cos2PhiQubit(base.QubitBaseClass, serializers.Serializable, NoisyCos2PhiQu
     def d_hamiltonian_d_ng(
         self, energy_esys: Union[bool, Tuple[ndarray, ndarray]] = False
     ) -> Union[ndarray, csc_matrix]:
-        """
+        r"""
         Returns operator representing a derivative of the Hamiltonian with respect to
         ng in the native or eigenenergy basis.
 
         Parameters
         ----------
         energy_esys:
-            If `False` (default), returns operator in the native basis.
-            If `True`, the energy eigenspectrum is computed, returns operator in the energy eigenbasis.
-            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues and energy eigenvectors),
-            returns operator in the energy eigenbasis, and does not have to recalculate eigenspectrum.
+            If `False` (default), returns operator in the harmonic oscillator basis.
+            If `True`, the energy eigenspectrum is computed, returns operator in the 
+            energy eigenbasis.
+            If `energy_esys = esys`, where esys is a tuple containing two ndarrays (eigenvalues 
+            and energy eigenvectors), returns operator in the energy eigenbasis, and does not 
+            have to recalculate eigenspectrum.
 
         Returns
         -------
-            Operator in chosen basis. If native basis chosen, operator
+            Operator in chosen basis. If harmonic oscillator basis chosen, operator
             returned as a csc_matrix. If the eigenenergy basis is chosen,
             unless `energy_esys` is specified, operator has dimensions of `truncated_dim`
-            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy basis is chosen,
-            operator has dimensions of m x m, for m given eigenvectors, and is returned as an ndarray.
+            x truncated_dim, and is returned as an ndarray. Otherwise, if eigenenergy 
+            basis is chosen, operator has dimensions of m x m, for m given eigenvectors, 
+            and is returned as an ndarray.
+
         """
         native = (
             4 * self.dCJ * self._disordered_ecj() * self.n_phi_operator()


### PR DESCRIPTION
Code documentation for cos2phi_qubit.py files for all the functions, methods and classes. 

The documentation follows the required guidelines as provided by the examples in the original issue. 

Fix for #222.