### PR TITLE
Update image name oscillator.jpg -> Oscillator.jpg

### DIFF
--- a/scqubits/core/oscillator.py
+++ b/scqubits/core/oscillator.py
@@ -105,7 +105,7 @@ class Oscillator(base.QuantumSystem, serializers.Serializable):
         self.l_osc: Union[None, float] = l_osc  # type:ignore
         self.E_osc = E_osc
         self._image_filename = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "qubit_img/oscillator.jpg"
+            os.path.dirname(os.path.abspath(__file__)), "qubit_img/Oscillator.jpg"
         )
 
     @staticmethod


### PR DESCRIPTION
source for image at https://github.com/scqubits/scqubits/blob/main/scqubits/core/qubit_img/Oscillator.jpg is different from what being loaded causing a file not found error.