### PR TITLE
Fix plotting of Cos2PhiQubit's wavefunctions in the GUI

### DIFF
--- a/scqubits/core/zeropi.py
+++ b/scqubits/core/zeropi.py
@@ -278,7 +278,7 @@ class ZeroPi(base.QubitBaseClass, serializers.Serializable, NoisyZeroPi):
         return self.grid.pt_count * (2 * self.ncut + 1)
 
     def potential(self, phi: ndarray, theta: ndarray) -> ndarray:
-        """
+        r"""
         Returns
         -------
             value of the potential energy evaluated at :math:`\phi`, :math:`\theta`
@@ -807,7 +807,7 @@ class ZeroPi(base.QubitBaseClass, serializers.Serializable, NoisyZeroPi):
         zero_calibrate: bool = True,
         **kwargs,
     ) -> Tuple[Figure, Axes]:
-        """Plots 2d phase-basis wave function.
+        r"""Plots 2d phase-basis wave function.
 
         Parameters
         ----------
@@ -816,7 +816,7 @@ class ZeroPi(base.QubitBaseClass, serializers.Serializable, NoisyZeroPi):
         which:
             index of wave function to be plotted (default value = 0)
         theta_grid:
-            used for setting a custom grid for theta; if None use self._default_grid
+            used for setting a custom grid for :math:`\theta`; if None use self._default_grid
         mode:
             choices as specified in `constants.MODE_FUNC_DICT`
             (default value = 'abs')

--- a/scqubits/ui/gui.py
+++ b/scqubits/ui/gui.py
@@ -11,13 +11,11 @@
 ############################################################################
 
 import math
-
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
-
 from matplotlib.figure import Axes, Figure
 
 import scqubits as scq
@@ -25,7 +23,6 @@ import scqubits.ui.gui_custom_widgets as ui
 import scqubits.ui.gui_defaults as gui_defaults
 import scqubits.ui.gui_navbar as gui_navbar
 import scqubits.utils.misc as utils
-
 from scqubits.core.discretization import Grid1d
 from scqubits.settings import matplotlib_settings
 from scqubits.ui.gui_custom_widgets import flex_column, flex_row
@@ -885,13 +882,21 @@ class GUI:
             value_dict["phi_grid"] = Grid1d(
                 min_val=self.dict_v_ranges["phi"]["min"].num_value,
                 max_val=self.dict_v_ranges["phi"]["max"].num_value,
-                pt_count=self.active_qubit._default_grid.pt_count,
+                pt_count=getattr(
+                    self.active_qubit,
+                    "_default_grid",
+                    getattr(self.active_qubit, "_default_phi_grid"),
+                ).pt_count,
             )
         if isinstance(self.active_qubit, QUBITS_WITH_THETA_GRID):
             value_dict["theta_grid"] = Grid1d(
                 min_val=self.dict_v_ranges["theta"]["min"].num_value,
                 max_val=self.dict_v_ranges["theta"]["max"].num_value,
-                pt_count=self.active_qubit._default_grid.pt_count,
+                pt_count=getattr(
+                    self.active_qubit,
+                    "_default_grid",
+                    getattr(self.active_qubit, "_default_theta_grid"),
+                ).pt_count,
             )
         self.wavefunctions_plot(**value_dict)
 


### PR DESCRIPTION
When trying to plot the wavefunctions of the Cos2PhiQubit from the GUI, we get an error because it has no attribute `_default_grid`.

This change makes it looks for `_default_phi_grid` (resp `_default_theta_grid`) when the object has not attribute `_default_grid`.