### PR TITLE
ci: disable mamba-pytests workflow; add dedicated mypy check

### DIFF
--- a/.github/workflows/mamba-install-and-run-pytests.yml
+++ b/.github/workflows/mamba-install-and-run-pytests.yml
@@ -1,11 +1,6 @@
 name: Locally install scqubits with mambabuild and run pytests
 
-on: 
-  push: 
-    branches:
-      - main
-      - devel_peterg
-      - spc-main-devel
+on:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - name: Install scqubits + mypy
+      - name: Install scqubits + dev deps (includes mypy, stubs)
         run: |
-          pip install ".[develop]"
+          pip install ".[gui,develop]"
           pip install mypy==1.19.1
       - name: Run mypy
         run: mypy scqubits/

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,22 @@
+name: mypy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install scqubits + mypy
+        run: |
+          pip install ".[develop]"
+          pip install mypy==1.19.1
+      - name: Run mypy
+        run: mypy scqubits/

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -17,7 +17,12 @@ jobs:
       - name: Install scqubits + dev deps (includes mypy, stubs)
         run: |
           pip install ".[gui,develop]"
-          pip install mypy==1.19.1
+          # numpy 2.x introduced tighter scalar typing (explicit _32Bit/_64Bit
+          # variants) that cascades through scipy-stubs and surfaces ~17
+          # strictness errors vs the numpy 1.x types the typing cleanup was
+          # verified against. scqubits itself runs fine on numpy 2 (Azure
+          # pytest covers that); this pin is mypy-specific.
+          pip install mypy==1.19.1 "numpy<2"
       - name: Show resolved versions
         run: pip list | grep -iE "^(scipy|mypy|types|numpy|tqdm|ipython|qutip)"
       - name: Run mypy

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Install scqubits + dev deps (includes mypy, stubs)
         run: |
           pip install ".[gui,develop]"
-          pip install mypy==1.19.1
+          pip install mypy==1.19.1 scipy-stubs==1.15.2.2
       - name: Run mypy
         run: mypy scqubits/

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Install scqubits + dev deps (includes mypy, stubs)
         run: |
           pip install ".[gui,develop]"
-          pip install mypy==1.19.1 scipy-stubs==1.15.2.2
+          pip install mypy==1.19.1
+      - name: Show resolved versions
+        run: pip list | grep -iE "^(scipy|mypy|types|numpy|tqdm|ipython|qutip)"
       - name: Run mypy
         run: mypy scqubits/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ gui = [
 ]
 develop = [
     "pytest", "traitlets", "h5py (>=2.10)",
+    "mypy", "types-tqdm", "scipy-stubs",
 ]
 
 [project.urls]
@@ -65,12 +66,15 @@ python_version = "3.10"
 warn_unused_ignores = true
 no_implicit_optional = true
 
-# Third-party packages without type stubs on PyPI (checked 2026-04-18):
+# Third-party packages without type stubs on PyPI (checked 2026-04-23):
 # - qutip, sympy, dill, h5py, pathos, ipywidgets, ipyvuetify, labellines,
 #   matplotlib_inline, mpl_toolkits.axes_grid1, mpl_toolkits.mplot3d
-# For tqdm, types-tqdm is installed via develop extras.
-# For matplotlib overall, no good stubs exist (unofficial matplotlib-stubs
-# has too many coverage gaps — causes more false positives than it fixes).
+# For tqdm and scipy, real stub packages (types-tqdm, scipy-stubs) are
+# installed via the `develop` extra. For matplotlib overall, no good stubs
+# exist (unofficial matplotlib-stubs has too many coverage gaps — causes
+# more false positives than it fixes). For IPython, install via
+# `pip install ".[gui,develop]"`: IPython comes in transitively through
+# ipywidgets (in the `gui` extra) and ships py.typed-marked inline types.
 [[tool.mypy.overrides]]
 module = [
     "dill",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ gui = [
 ]
 develop = [
     "pytest", "traitlets", "h5py (>=2.10)",
-    "mypy", "types-tqdm", "scipy-stubs",
+    "mypy", "types-tqdm", "scipy-stubs==1.15.2.2",
 ]
 
 [project.urls]

--- a/scqubits/core/noise.py
+++ b/scqubits/core/noise.py
@@ -326,7 +326,7 @@ class NoisySystem(ABC):
                 )
 
             ax = (
-                axes.ravel()[channel_idx]  # type: ignore[union-attr]
+                axes.ravel()[channel_idx]
                 if len(noise_channels) > 1
                 else axes
             )
@@ -338,16 +338,16 @@ class NoisySystem(ABC):
             # check whether rate is essentially zero and decoherence time thus
             # excessively large
             if np.all(noise_vals / scale > 1e12):
-                ax.get_lines()[0].set_color("0.8")  # type: ignore[union-attr]
+                ax.get_lines()[0].set_color("0.8")
                 at = AnchoredText(
                     "subdominant noise channel",
                     frameon=False,
                     loc="center",
                 )
-                ax.add_artist(at)  # type: ignore[union-attr]
+                ax.add_artist(at)
 
         if len(noise_channels) > 1 and len(noise_channels) % 2:
-            axes.ravel()[-1].set_axis_off()  # type: ignore[union-attr]
+            axes.ravel()[-1].set_axis_off()
 
         # Set the parameter we varied to its initial value
         setattr(self, param_name, current_val)

--- a/scqubits/core/noise.py
+++ b/scqubits/core/noise.py
@@ -325,11 +325,7 @@ class NoisySystem(ABC):
                     " or list of tuples}."
                 )
 
-            ax = (
-                axes.ravel()[channel_idx]
-                if len(noise_channels) > 1
-                else axes
-            )
+            ax = axes.ravel()[channel_idx] if len(noise_channels) > 1 else axes
             plotting_options["fig_ax"] = fig, ax
             plotting_options["title"] = noise_channel_method
             plotting.data_vs_paramvals(

--- a/scqubits/explorer/explorer_widget.py
+++ b/scqubits/explorer/explorer_widget.py
@@ -644,7 +644,7 @@ class Explorer:
         for axes in self.axes_list:
             for item in axes.lines + axes.collections + axes.texts:  # type: ignore[operator]
                 item.remove()
-            axes.set_prop_cycle(None)  # type: ignore[call-overload]
+            axes.set_prop_cycle(None)
             axes.relim()
             axes.autoscale_view()
 

--- a/scqubits/ui/gui.py
+++ b/scqubits/ui/gui.py
@@ -1673,14 +1673,14 @@ class GUI:
                     param_vals=np_list,
                     noise_channels=noise_channels["t1_eff"],
                     common_noise_options=common_noise_options,
-                    fig_ax=(self.fig, ax[0]),  # type: ignore[index]
+                    fig_ax=(self.fig, ax[0]),
                 )
                 self.active_qubit.plot_t2_effective_vs_paramvals(
                     param_name=scan_value,
                     param_vals=np_list,
                     noise_channels=noise_channels["t2_eff"],
                     common_noise_options=common_noise_options,
-                    fig_ax=(self.fig, ax[1]),  # type: ignore[index]
+                    fig_ax=(self.fig, ax[1]),
                 )
             self.plot_renewal_requested = False
             if _HAS_WIDGET_BACKEND:


### PR DESCRIPTION
The mamba-install-and-run-pytests workflow has been leaving runs indefinitely in_progress due to Windows Python 3.12 hanging on "Build with mambabuild" (pure-Python package, so the conda recipe build is unnecessary overhead; no job timeout). Azure Pipelines already runs the full pytest matrix on pushes and PRs and is the sole pytest CI going forward. Kept the workflow definition but reduced its trigger to workflow_dispatch so it can still be run manually if needed for conda validation.

Added a dedicated mypy workflow (ubuntu, Python 3.10, mypy==1.19.1) that runs on every push to main and every pull request. Pinning mypy to the version the typing cleanup was verified against avoids surprise CI failures from upstream mypy upgrades — upgrades become an explicit bump-the-pin PR. Without this gate, the 858-error typing cleanup would drift unchecked.