### PR TITLE
refactor(deps): move _optional_deps to utils + drop unused HTML / blanket noqa

### DIFF
--- a/scqubits/core/circuit.py
+++ b/scqubits/core/circuit.py
@@ -24,7 +24,7 @@ import sympy as sm
 from numpy import ndarray
 from sympy import latex
 
-from scqubits.ui._optional_deps import _HAS_IPYTHON
+from scqubits.utils._optional_deps import _HAS_IPYTHON
 
 import scqubits.core.central_dispatch as dispatch
 import scqubits.core.discretization as discretization

--- a/scqubits/core/circuit_internals/sym_methods.py
+++ b/scqubits/core/circuit_internals/sym_methods.py
@@ -21,7 +21,7 @@ import sympy as sm
 
 from sympy import latex
 
-from scqubits.ui._optional_deps import _HAS_IPYTHON, Latex, display
+from scqubits.utils._optional_deps import _HAS_IPYTHON, Latex, display
 
 __all__ = [
     "CircuitSymMethods",

--- a/scqubits/explorer/explorer_internals/ac_stark.py
+++ b/scqubits/explorer/explorer_internals/ac_stark.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from scqubits.explorer.explorer_settings import ExplorerSettings
     from scqubits.explorer.explorer_widget import Explorer, PlotID
 
-from scqubits.utils._optional_deps import _HAS_IPYVUETIFY, v  # noqa: F401
+from scqubits.utils._optional_deps import _HAS_IPYVUETIFY, v
 
 
 class AcStarkPanelBuilder:

--- a/scqubits/explorer/explorer_internals/ac_stark.py
+++ b/scqubits/explorer/explorer_internals/ac_stark.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from scqubits.explorer.explorer_settings import ExplorerSettings
     from scqubits.explorer.explorer_widget import Explorer, PlotID
 
-from scqubits.ui._optional_deps import _HAS_IPYVUETIFY, v  # noqa: F401
+from scqubits.utils._optional_deps import _HAS_IPYVUETIFY, v  # noqa: F401
 
 
 class AcStarkPanelBuilder:

--- a/scqubits/explorer/explorer_internals/energy_spectrum.py
+++ b/scqubits/explorer/explorer_internals/energy_spectrum.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from scqubits.explorer.explorer_settings import ExplorerSettings
     from scqubits.explorer.explorer_widget import Explorer, PlotID
 
-from scqubits.ui._optional_deps import _HAS_IPYVUETIFY, v  # noqa: F401
+from scqubits.utils._optional_deps import _HAS_IPYVUETIFY, v  # noqa: F401
 
 
 @rc_context(matplotlib_settings)

--- a/scqubits/explorer/explorer_internals/energy_spectrum.py
+++ b/scqubits/explorer/explorer_internals/energy_spectrum.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from scqubits.explorer.explorer_settings import ExplorerSettings
     from scqubits.explorer.explorer_widget import Explorer, PlotID
 
-from scqubits.utils._optional_deps import _HAS_IPYVUETIFY, v  # noqa: F401
+from scqubits.utils._optional_deps import _HAS_IPYVUETIFY, v
 
 
 @rc_context(matplotlib_settings)

--- a/scqubits/explorer/explorer_internals/transitions.py
+++ b/scqubits/explorer/explorer_internals/transitions.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from scqubits.explorer.explorer_settings import ExplorerSettings
     from scqubits.explorer.explorer_widget import Explorer, PlotID
 
-from scqubits.utils._optional_deps import _HAS_IPYVUETIFY, v  # noqa: F401
+from scqubits.utils._optional_deps import _HAS_IPYVUETIFY, v
 
 
 @rc_context(matplotlib_settings)

--- a/scqubits/explorer/explorer_internals/transitions.py
+++ b/scqubits/explorer/explorer_internals/transitions.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from scqubits.explorer.explorer_settings import ExplorerSettings
     from scqubits.explorer.explorer_widget import Explorer, PlotID
 
-from scqubits.ui._optional_deps import _HAS_IPYVUETIFY, v  # noqa: F401
+from scqubits.utils._optional_deps import _HAS_IPYVUETIFY, v  # noqa: F401
 
 
 @rc_context(matplotlib_settings)

--- a/scqubits/explorer/explorer_settings.py
+++ b/scqubits/explorer/explorer_settings.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from scqubits import Explorer
     from scqubits.explorer.explorer_widget import PlotID
 
-from scqubits.ui._optional_deps import _HAS_IPYTHON, _HAS_IPYVUETIFY, v
+from scqubits.utils._optional_deps import _HAS_IPYTHON, _HAS_IPYVUETIFY, v
 
 
 class ExplorerSettings:

--- a/scqubits/explorer/explorer_widget.py
+++ b/scqubits/explorer/explorer_widget.py
@@ -44,7 +44,7 @@ from scqubits.utils.misc import _HAS_WIDGET_BACKEND
 if TYPE_CHECKING:
     from scqubits.core.param_sweep import ParameterSweep
 
-from scqubits.ui._optional_deps import _HAS_IPYTHON, _HAS_IPYVUETIFY, display, v
+from scqubits.utils._optional_deps import _HAS_IPYTHON, _HAS_IPYVUETIFY, display, v
 
 
 class PlotID:

--- a/scqubits/tests/test_explorer_internals.py
+++ b/scqubits/tests/test_explorer_internals.py
@@ -153,13 +153,13 @@ def test_explorer_ui_default_instance_is_empty():
 
 
 def test_optional_deps_module_exposes_expected_names():
-    """``scqubits.ui._optional_deps`` is the single source of truth for
+    """``scqubits.utils._optional_deps`` is the single source of truth for
     the ipyvuetify / IPython availability flags + module references.
 
     Catches accidental name drops (or silent renames) that would force
     callers back to per-file ``try/except ImportError`` boilerplate.
     """
-    from scqubits.ui import _optional_deps
+    from scqubits.utils import _optional_deps
 
     for name in (
         "_HAS_IPYVUETIFY",
@@ -171,7 +171,7 @@ def test_optional_deps_module_exposes_expected_names():
     ):
         assert hasattr(
             _optional_deps, name
-        ), f"scqubits.ui._optional_deps missing expected symbol: {name!r}"
+        ), f"scqubits.utils._optional_deps missing expected symbol: {name!r}"
 
     assert isinstance(_optional_deps._HAS_IPYVUETIFY, bool)
     assert isinstance(_optional_deps._HAS_IPYTHON, bool)

--- a/scqubits/tests/test_explorer_internals.py
+++ b/scqubits/tests/test_explorer_internals.py
@@ -167,7 +167,6 @@ def test_optional_deps_module_exposes_expected_names():
         "v",
         "ipywidgets",
         "display",
-        "HTML",
     ):
         assert hasattr(
             _optional_deps, name

--- a/scqubits/ui/gui.py
+++ b/scqubits/ui/gui.py
@@ -43,7 +43,7 @@ from scqubits.ui.gui_setup import (
 )
 from scqubits.utils.misc import _HAS_WIDGET_BACKEND
 
-from scqubits.utils._optional_deps import (  # noqa: F401
+from scqubits.utils._optional_deps import (
     _HAS_IPYTHON,
     _HAS_IPYVUETIFY,
     display,

--- a/scqubits/ui/gui.py
+++ b/scqubits/ui/gui.py
@@ -43,7 +43,7 @@ from scqubits.ui.gui_setup import (
 )
 from scqubits.utils.misc import _HAS_WIDGET_BACKEND
 
-from scqubits.ui._optional_deps import (  # noqa: F401
+from scqubits.utils._optional_deps import (  # noqa: F401
     _HAS_IPYTHON,
     _HAS_IPYVUETIFY,
     display,

--- a/scqubits/ui/gui_custom_widgets.py
+++ b/scqubits/ui/gui_custom_widgets.py
@@ -21,7 +21,7 @@ import matplotlib as mp
 
 import scqubits.utils.misc as utils
 
-from scqubits.utils._optional_deps import (  # noqa: F401
+from scqubits.utils._optional_deps import (
     _HAS_IPYTHON,
     _HAS_IPYVUETIFY,
     display,

--- a/scqubits/ui/gui_custom_widgets.py
+++ b/scqubits/ui/gui_custom_widgets.py
@@ -21,7 +21,7 @@ import matplotlib as mp
 
 import scqubits.utils.misc as utils
 
-from scqubits.ui._optional_deps import (  # noqa: F401
+from scqubits.utils._optional_deps import (  # noqa: F401
     _HAS_IPYTHON,
     _HAS_IPYVUETIFY,
     display,

--- a/scqubits/ui/gui_defaults.py
+++ b/scqubits/ui/gui_defaults.py
@@ -19,7 +19,7 @@ import os
 
 from collections.abc import Sequence
 
-from scqubits.ui._optional_deps import _HAS_IPYVUETIFY, ipywidgets, v  # noqa: F401
+from scqubits.utils._optional_deps import _HAS_IPYVUETIFY, ipywidgets, v  # noqa: F401
 
 gui_plot_choice_dict = collections.OrderedDict(
     [

--- a/scqubits/ui/gui_defaults.py
+++ b/scqubits/ui/gui_defaults.py
@@ -19,7 +19,7 @@ import os
 
 from collections.abc import Sequence
 
-from scqubits.utils._optional_deps import _HAS_IPYVUETIFY, ipywidgets, v  # noqa: F401
+from scqubits.utils._optional_deps import _HAS_IPYVUETIFY, ipywidgets, v
 
 gui_plot_choice_dict = collections.OrderedDict(
     [

--- a/scqubits/ui/gui_navbar.py
+++ b/scqubits/ui/gui_navbar.py
@@ -19,13 +19,7 @@ from scqubits.ui import gui_defaults as gui_defaults
 from scqubits.ui.gui_custom_widgets import flex_column
 from scqubits.ui.gui_defaults import NAV_COLOR
 
-from scqubits.utils._optional_deps import (  # noqa: F401
-    _HAS_IPYTHON,
-    _HAS_IPYVUETIFY,
-    display,
-    ipywidgets,
-    v,
-)
+from scqubits.utils._optional_deps import _HAS_IPYTHON, _HAS_IPYVUETIFY, v
 
 
 @utils.Required(ipyvuetify=_HAS_IPYVUETIFY, IPython=_HAS_IPYTHON)

--- a/scqubits/ui/gui_navbar.py
+++ b/scqubits/ui/gui_navbar.py
@@ -19,7 +19,7 @@ from scqubits.ui import gui_defaults as gui_defaults
 from scqubits.ui.gui_custom_widgets import flex_column
 from scqubits.ui.gui_defaults import NAV_COLOR
 
-from scqubits.ui._optional_deps import (  # noqa: F401
+from scqubits.utils._optional_deps import (  # noqa: F401
     _HAS_IPYTHON,
     _HAS_IPYVUETIFY,
     display,

--- a/scqubits/ui/gui_setup.py
+++ b/scqubits/ui/gui_setup.py
@@ -25,7 +25,7 @@ from scqubits.core.qubit_base import QubitBaseClass
 from scqubits.ui import gui_custom_widgets as ui
 from scqubits.ui import gui_defaults as gui_defaults
 
-from scqubits.ui._optional_deps import (  # noqa: F401
+from scqubits.utils._optional_deps import (  # noqa: F401
     _HAS_IPYTHON,
     _HAS_IPYVUETIFY,
     display,

--- a/scqubits/ui/gui_setup.py
+++ b/scqubits/ui/gui_setup.py
@@ -25,13 +25,7 @@ from scqubits.core.qubit_base import QubitBaseClass
 from scqubits.ui import gui_custom_widgets as ui
 from scqubits.ui import gui_defaults as gui_defaults
 
-from scqubits.utils._optional_deps import (  # noqa: F401
-    _HAS_IPYTHON,
-    _HAS_IPYVUETIFY,
-    display,
-    ipywidgets,
-    v,
-)
+from scqubits.utils._optional_deps import _HAS_IPYTHON, _HAS_IPYVUETIFY, ipywidgets, v
 
 
 @utils.Required(ipyvuetify=_HAS_IPYVUETIFY, IPython=_HAS_IPYTHON)

--- a/scqubits/ui/hspace_widget.py
+++ b/scqubits/ui/hspace_widget.py
@@ -24,7 +24,7 @@ from scipy.sparse import csc_matrix
 
 from scqubits.ui.gui_defaults import NAV_COLOR
 
-from scqubits.utils._optional_deps import (  # noqa: F401
+from scqubits.utils._optional_deps import (
     _HAS_IPYTHON,
     _HAS_IPYVUETIFY,
     display,

--- a/scqubits/ui/hspace_widget.py
+++ b/scqubits/ui/hspace_widget.py
@@ -24,7 +24,7 @@ from scipy.sparse import csc_matrix
 
 from scqubits.ui.gui_defaults import NAV_COLOR
 
-from scqubits.ui._optional_deps import (  # noqa: F401
+from scqubits.utils._optional_deps import (  # noqa: F401
     _HAS_IPYTHON,
     _HAS_IPYVUETIFY,
     display,

--- a/scqubits/ui/qubit_widget.py
+++ b/scqubits/ui/qubit_widget.py
@@ -18,13 +18,13 @@ from typing import Any
 import scqubits.core.units as units
 import scqubits.utils.misc as utils
 
-from scqubits.utils._optional_deps import (  # noqa: F401
+from scqubits.utils._optional_deps import (
     _HAS_IPYTHON,
     _HAS_IPYVUETIFY,
     display,
     ipywidgets,
 )
-from scqubits.utils._optional_deps import v as ipyvuetify  # noqa: F401
+from scqubits.utils._optional_deps import v as ipyvuetify
 
 if _HAS_IPYVUETIFY:
     from scqubits.ui.gui_custom_widgets import ValidatedNumberField

--- a/scqubits/ui/qubit_widget.py
+++ b/scqubits/ui/qubit_widget.py
@@ -18,13 +18,13 @@ from typing import Any
 import scqubits.core.units as units
 import scqubits.utils.misc as utils
 
-from scqubits.ui._optional_deps import (  # noqa: F401
+from scqubits.utils._optional_deps import (  # noqa: F401
     _HAS_IPYTHON,
     _HAS_IPYVUETIFY,
     display,
     ipywidgets,
 )
-from scqubits.ui._optional_deps import v as ipyvuetify  # noqa: F401
+from scqubits.utils._optional_deps import v as ipyvuetify  # noqa: F401
 
 if _HAS_IPYVUETIFY:
     from scqubits.ui.gui_custom_widgets import ValidatedNumberField

--- a/scqubits/utils/_optional_deps.py
+++ b/scqubits/utils/_optional_deps.py
@@ -5,7 +5,7 @@ flags plus the optional module references (``v``, ``display``, etc.)
 that the Explorer subsystem reaches for.  Files that previously
 duplicated the ``try: import ipyvuetify as v; except ImportError:
 _HAS_IPYVUETIFY = False; else: _HAS_IPYVUETIFY = True`` boilerplate
-can now ``from scqubits.ui._optional_deps import v, _HAS_IPYVUETIFY``.
+can now ``from scqubits.utils._optional_deps import v, _HAS_IPYVUETIFY``.
 
 When a dependency is missing, the corresponding name is set to
 ``None`` and the ``_HAS_*`` flag is ``False``.  Call sites that

--- a/scqubits/utils/_optional_deps.py
+++ b/scqubits/utils/_optional_deps.py
@@ -40,16 +40,13 @@ else:
 
 # IPython display: same pattern as above.
 try:
-    from IPython.display import HTML as _HTML
     from IPython.display import Latex as _Latex
     from IPython.display import display as _display
 except ImportError:
     _HAS_IPYTHON = False
-    HTML: Any = None
     Latex: Any = None
     display: Any = None
 else:
     _HAS_IPYTHON = True
-    HTML = _HTML
     Latex = _Latex
     display = _display


### PR DESCRIPTION
## Summary

Post-merge cleanup of three items flagged on PR #292:

1. **core -> ui layering inversion.** `scqubits/core/circuit.py` and `scqubits/core/circuit_internals/sym_methods.py` were importing `_HAS_IPYTHON` / `Latex` / `display` from `scqubits/ui/_optional_deps.py` to power their `_repr_latex_`. `scqubits/utils/` is already a cross-cutting utility sink that both `core/` and `ui/` legitimately depend on, so moving the optional-deps module there resolves the inversion without introducing new edges.
2. **Unused `HTML` export.** `_optional_deps` re-exported `IPython.display.HTML` but nothing in scqubits called it — only the test fixture pinned it. Dropped from both the module and the test.
3. **Blanket `# noqa: F401`.** The multi-name imports from `_optional_deps` carried a blanket suppression that was inert (the project does not configure ruff/flake8) and over-broad. Removed across all consumers. `gui_navbar.py` and `gui_setup.py` were also genuinely importing unused `display` / `ipywidgets`; those dead imports are dropped alongside the noqa.

## Verification

- `pytest test_explorer.py test_explorer_internals.py test_parametersweep.py` — 13 passed
- `mypy` on changed files — clean
- `black --check` on changed files — clean

## Notes

- The rename is tracked by git as a 95%-similarity move (commit `3e5bac8b`).
- No behavior change in any of the three commits; this is purely a structural / hygiene PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)