### PR TITLE
Add convergence diagnostics framework (energies, Transmon)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,11 @@ develop = [
 Homepage = "https://scqubits.readthedocs.io"
 Repository = "https://github.com/scqubits/scqubits"
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselect with -m 'not slow')",
+]
+
 [tool.black]
 target-version = ["py310"]
 

--- a/scqubits/__init__.py
+++ b/scqubits/__init__.py
@@ -32,6 +32,15 @@ from scqubits import settings
 
 # core
 from scqubits.core.central_dispatch import CentralDispatch
+from scqubits.core.convergence import (
+    ConvergenceCheckable,
+    estimate_convergence,
+)
+from scqubits.core.convergence_report import (
+    ConvergenceReport,
+    ImplementationAudit,
+    LevelVerdict,
+)
 from scqubits.core.cos2phi_qubit import Cos2PhiQubit
 from scqubits.core.diag import DIAG_METHODS
 from scqubits.core.discretization import Grid1d

--- a/scqubits/core/convergence.py
+++ b/scqubits/core/convergence.py
@@ -426,161 +426,88 @@ class ConvergenceCheckable:
         """Assemble the LevelVerdicts and the ConvergenceReport from refinement
         eigenvalues. Shared between verify and strict modes."""
         channel: TruncationChannel = self._convergence_truncation_channel(axis)
-        cluster_threshold = settings.CONVERGENCE_CLUSTER_RATIO
         safety_factor = settings.CONVERGENCE_SAFETY_FACTOR
 
-        # Cluster-detect on N0 (the reference / user's current spectrum).
+        # Cluster-detect on N0 (the reference / user's current spectrum) and
+        # measure the one-step movement N0 -> N1 per cluster.
         clusters = cutils.detect_clusters(
-            evals_n0, gap_ratio_threshold=cluster_threshold
+            evals_n0, gap_ratio_threshold=settings.CONVERGENCE_CLUSTER_RATIO
         )
         _, cluster_max_diff_n1 = cutils.cluster_safe_match_energies(
             evals_n0, evals_n1, clusters
         )
 
-        # Per-level: assign the cluster-level estimate to every member.
-        per_level_estimate = np.empty(n_levels, dtype=np.float64)
-        for cluster_idx, cluster in enumerate(clusters):
-            for k in cluster:
-                per_level_estimate[k] = cluster_max_diff_n1[cluster_idx]
-
-        # Strict mode: ratio test.
-        ratio_per_cluster: npt.NDArray[np.float64] | None = None
+        # Strict mode: a second refinement enables the geometric ratio test.
         geometric_tail: npt.NDArray[np.float64] | None = None
         asymptotic_flag: npt.NDArray[np.bool_] | None = None
         if refinement == "ratio_test" and evals_n2 is not None:
             _, cluster_max_diff_n2 = cutils.cluster_safe_match_energies(
                 evals_n1, evals_n2, clusters
             )
-            ratio_per_cluster = np.divide(
-                cluster_max_diff_n2,
-                cluster_max_diff_n1,
-                out=np.full_like(cluster_max_diff_n1, np.inf),
-                where=cluster_max_diff_n1 > 0,
+            _, geometric_tail, asymptotic_flag = cutils.geometric_ratio_test(
+                cluster_max_diff_n1, cluster_max_diff_n2
             )
-            # Geometric-tail estimate: d0 / (1 - R) when R < 1.
-            geometric_tail = np.where(
-                ratio_per_cluster < 1.0,
-                cluster_max_diff_n1 / np.clip(1.0 - ratio_per_cluster, 1e-30, None),
-                np.inf,
-            )
-            asymptotic_flag = ratio_per_cluster < 1.0
 
-        # If strict-mode geometric tail succeeded, use that as the
-        # estimate; otherwise stick with safety_factor * d0.
-        per_level_abs_err = np.empty(n_levels, dtype=np.float64)
-        per_level_evidence: list[Evidence] = []
-        per_level_estimator_method: list[str] = []
-        per_level_warnings: list[list[str]] = [[] for _ in range(n_levels)]
+        (
+            per_level_abs_err,
+            per_level_evidence,
+            per_level_estimator_method,
+            per_level_warnings,
+        ) = _per_cluster_energy_estimates(
+            clusters=clusters,
+            cluster_max_diff_n1=cluster_max_diff_n1,
+            refinement=refinement,
+            geometric_tail=geometric_tail,
+            asymptotic_flag=asymptotic_flag,
+            safety_factor=safety_factor,
+            n_levels=n_levels,
+        )
 
-        for cluster_idx, cluster in enumerate(clusters):
-            if refinement == "ratio_test" and geometric_tail is not None:
-                if asymptotic_flag is not None and asymptotic_flag[cluster_idx]:
-                    est = float(geometric_tail[cluster_idx])
-                    ev: Evidence = "calibrated"
-                    method = "ratio_test"
-                else:
-                    est = float(safety_factor * cluster_max_diff_n1[cluster_idx])
-                    ev = "verified_empirical"
-                    method = "ratio_test_failed_fallback_one_step"
-                    for k in cluster:
-                        per_level_warnings[k].append("ratio_test_not_asymptotic")
-            else:
-                est = float(safety_factor * cluster_max_diff_n1[cluster_idx])
-                ev = "verified_empirical"
-                method = "one_step"
+        eps_gap_est = _observed_gap_eps(
+            scope=scope,
+            evals_n0=evals_n0,
+            buffer_n0=buffer_n0,
+            n_levels=n_levels,
+            g_floor_GHz=g_floor_GHz,
+            per_level_abs_err=per_level_abs_err,
+            per_level_warnings=per_level_warnings,
+        )
 
-            for k in cluster:
-                per_level_abs_err[k] = est
-                per_level_evidence.append(ev)
-                per_level_estimator_method.append(method)
+        per_level_status = _assign_level_statuses(
+            n_levels=n_levels,
+            per_level_abs_err=per_level_abs_err,
+            eps_gap_est=eps_gap_est,
+            per_level_evidence=per_level_evidence,
+            per_level_warnings=per_level_warnings,
+            scope=scope,
+            target_abs_GHz=target_abs_GHz,
+            target_gap_rel=target_gap_rel,
+            mode=mode,
+        )
 
-        # Observed-gap scope: compute local isolation gaps from N0 spectrum.
-        eps_gap_est: list[float | None]
-        if scope == "observed_gap_scale":
-            eps_gap_est = []
-            for k in range(n_levels):
-                gap = _local_isolation_gap(
-                    evals_n0=evals_n0,
-                    buffer_n0=buffer_n0,
-                    k=k,
-                    n_levels=n_levels,
-                    g_floor=g_floor_GHz,
-                )
-                if gap is None:
-                    # Topmost level without buffer: cannot compute upper gap.
-                    eps_gap_est.append(None)
-                    per_level_warnings[k].append("upper_gap_unavailable")
-                else:
-                    eps_gap_est.append(float(per_level_abs_err[k] / gap))
-        else:
-            eps_gap_est = [None] * n_levels
-
-        # Assign status per level based on chosen scope and target.
-        per_level_status: list[Status] = []
-        for k in range(n_levels):
-            status = _assign_status(
-                abs_err_est=float(per_level_abs_err[k]),
+        per_level_verdicts = [
+            LevelVerdict(
+                level_index=k,
+                status=per_level_status[k],
+                status_scope=scope,  # type: ignore[arg-type]
+                evidence=per_level_evidence[k],
+                abs_err_est_GHz=float(per_level_abs_err[k]),
                 eps_gap_est=eps_gap_est[k],
-                scope=scope,
-                target_abs_GHz=target_abs_GHz,
-                target_gap_rel=target_gap_rel,
+                truncation_channel=channel,
+                estimator_method=per_level_estimator_method[k],
+                warnings=tuple(per_level_warnings[k]),
             )
-            # Strict mode downgrades any status weaker than verified_empirical.
-            if mode == "strict" and status == "converged":
-                if not evidence_at_least(per_level_evidence[k], "verified_empirical"):
-                    status = "marginal"
-                    per_level_warnings[k].append(
-                        "strict_mode_downgrade_insufficient_evidence"
-                    )
-            per_level_status.append(status)
+            for k in range(n_levels)
+        ]
 
-        # Build LevelVerdicts.
-        per_level_verdicts: list[LevelVerdict] = []
-        for k in range(n_levels):
-            per_level_verdicts.append(
-                LevelVerdict(
-                    level_index=k,
-                    status=per_level_status[k],
-                    status_scope=scope,  # type: ignore[arg-type]
-                    evidence=per_level_evidence[k],
-                    abs_err_est_GHz=float(per_level_abs_err[k]),
-                    eps_gap_est=eps_gap_est[k],
-                    truncation_channel=channel,
-                    estimator_method=per_level_estimator_method[k],
-                    warnings=tuple(per_level_warnings[k]),
-                )
-            )
+        worst_idx, aggregate_status = _aggregate_worst(per_level_verdicts)
 
-        # Aggregate worst status.
-        worst_rank = -1
-        worst_idx = 0
-        for k, v in enumerate(per_level_verdicts):
-            r = _status_rank(v.status)
-            if r > worst_rank:
-                worst_rank = r
-                worst_idx = k
-        aggregate_status: Status = per_level_verdicts[worst_idx].status
-
-        # Recommendations.
-        recommendations: list[str] = []
-        if any(v.status == "underconverged" for v in per_level_verdicts):
-            current_value = int(getattr(self, axis))
-            step = self._convergence_step(axis)
-            recommendations.append(
-                f"increase {axis} from {current_value} to at least "
-                f"{current_value + step} and re-run; the worst-level "
-                f"estimate exceeded the target threshold"
-            )
-        if (
-            scope == "absolute"
-            and target_abs_GHz is None
-            and any(v.status == "unverified" for v in per_level_verdicts)
-        ):
-            recommendations.append(
-                "supply target_abs_GHz for an automatic status assignment "
-                "in absolute scope; report currently exposes abs_err_est_GHz "
-                "per level without thresholding"
-            )
+        recommendations = self._energy_recommendations(
+            verdicts=per_level_verdicts,
+            scope=scope,
+            target_abs_GHz=target_abs_GHz,
+            axis=axis,
+        )
 
         return ConvergenceReport(
             per_level=per_level_verdicts,
@@ -598,6 +525,40 @@ class ConvergenceCheckable:
                 refinement=refinement,
             ),
         )
+
+    def _energy_recommendations(
+        self,
+        verdicts: list[LevelVerdict],
+        scope: str,
+        target_abs_GHz: float | None,
+        axis: str,
+    ) -> list[str]:
+        """Build the next-step recommendations for an energy convergence report.
+
+        Suggests increasing the truncation axis when any level is
+        underconverged, and prompts for a ``target_abs_GHz`` when absolute-scope
+        levels are unverified for lack of a target.
+        """
+        recommendations: list[str] = []
+        if any(v.status == "underconverged" for v in verdicts):
+            current_value = int(getattr(self, axis))
+            step = self._convergence_step(axis)
+            recommendations.append(
+                f"increase {axis} from {current_value} to at least "
+                f"{current_value + step} and re-run; the worst-level "
+                f"estimate exceeded the target threshold"
+            )
+        if (
+            scope == "absolute"
+            and target_abs_GHz is None
+            and any(v.status == "unverified" for v in verdicts)
+        ):
+            recommendations.append(
+                "supply target_abs_GHz for an automatic status assignment "
+                "in absolute scope; report currently exposes abs_err_est_GHz "
+                "per level without thresholding"
+            )
+        return recommendations
 
 
 # ------------------------------------------------------------ module helpers
@@ -683,6 +644,143 @@ def _assign_status(
     if eps_gap_est < 10.0 * target_gap_rel:
         return "marginal"
     return "underconverged"
+
+
+def _per_cluster_energy_estimates(
+    clusters: list[tuple[int, ...]],
+    cluster_max_diff_n1: npt.NDArray[np.float64],
+    refinement: str,
+    geometric_tail: npt.NDArray[np.float64] | None,
+    asymptotic_flag: npt.NDArray[np.bool_] | None,
+    safety_factor: float,
+    n_levels: int,
+) -> tuple[npt.NDArray[np.float64], list[Evidence], list[str], list[list[str]]]:
+    """Derive each level's error estimate, evidence, estimator method, and warnings.
+
+    Verify mode (and the strict-mode fallback) takes ``safety_factor`` times the
+    one-step movement, tagged ``verified_empirical``. Strict mode uses the
+    geometric-tail estimate tagged ``calibrated`` for clusters confirmed to be in
+    the asymptotic regime, and otherwise falls back to the one-step estimate and
+    records a ``ratio_test_not_asymptotic`` warning. Every level inherits the
+    values of the cluster it belongs to.
+    """
+    per_level_abs_err = np.empty(n_levels, dtype=np.float64)
+    per_level_evidence: list[Evidence] = []
+    per_level_estimator_method: list[str] = []
+    per_level_warnings: list[list[str]] = [[] for _ in range(n_levels)]
+
+    for cluster_idx, cluster in enumerate(clusters):
+        if refinement == "ratio_test" and geometric_tail is not None:
+            if asymptotic_flag is not None and asymptotic_flag[cluster_idx]:
+                est = float(geometric_tail[cluster_idx])
+                ev: Evidence = "calibrated"
+                method = "ratio_test"
+            else:
+                est = float(safety_factor * cluster_max_diff_n1[cluster_idx])
+                ev = "verified_empirical"
+                method = "ratio_test_failed_fallback_one_step"
+                for k in cluster:
+                    per_level_warnings[k].append("ratio_test_not_asymptotic")
+        else:
+            est = float(safety_factor * cluster_max_diff_n1[cluster_idx])
+            ev = "verified_empirical"
+            method = "one_step"
+
+        for k in cluster:
+            per_level_abs_err[k] = est
+            per_level_evidence.append(ev)
+            per_level_estimator_method.append(method)
+
+    return (
+        per_level_abs_err,
+        per_level_evidence,
+        per_level_estimator_method,
+        per_level_warnings,
+    )
+
+
+def _observed_gap_eps(
+    scope: str,
+    evals_n0: npt.NDArray[np.float64],
+    buffer_n0: npt.NDArray[np.float64] | None,
+    n_levels: int,
+    g_floor_GHz: float,
+    per_level_abs_err: npt.NDArray[np.float64],
+    per_level_warnings: list[list[str]],
+) -> list[float | None]:
+    """Normalize each level's error by its local isolation gap.
+
+    Returns ``None`` for every level outside ``observed_gap_scale`` scope.
+    Within that scope, each entry is the absolute error divided by the level's
+    local isolation gap; a level whose upper gap is unavailable (the topmost
+    requested level without a buffer) is left as ``None`` and gets an
+    ``upper_gap_unavailable`` warning.
+    """
+    if scope != "observed_gap_scale":
+        return [None] * n_levels
+    eps_gap_est: list[float | None] = []
+    for k in range(n_levels):
+        gap = _local_isolation_gap(
+            evals_n0=evals_n0,
+            buffer_n0=buffer_n0,
+            k=k,
+            n_levels=n_levels,
+            g_floor=g_floor_GHz,
+        )
+        if gap is None:
+            eps_gap_est.append(None)
+            per_level_warnings[k].append("upper_gap_unavailable")
+        else:
+            eps_gap_est.append(float(per_level_abs_err[k] / gap))
+    return eps_gap_est
+
+
+def _assign_level_statuses(
+    n_levels: int,
+    per_level_abs_err: npt.NDArray[np.float64],
+    eps_gap_est: list[float | None],
+    per_level_evidence: list[Evidence],
+    per_level_warnings: list[list[str]],
+    scope: str,
+    target_abs_GHz: float | None,
+    target_gap_rel: float,
+    mode: str,
+) -> list[Status]:
+    """Assign each level's Status from its error estimate and the active target.
+
+    In strict mode a ``converged`` verdict backed by evidence weaker than
+    ``verified_empirical`` is downgraded to ``marginal`` and a
+    ``strict_mode_downgrade_insufficient_evidence`` warning is recorded.
+    """
+    per_level_status: list[Status] = []
+    for k in range(n_levels):
+        status = _assign_status(
+            abs_err_est=float(per_level_abs_err[k]),
+            eps_gap_est=eps_gap_est[k],
+            scope=scope,
+            target_abs_GHz=target_abs_GHz,
+            target_gap_rel=target_gap_rel,
+        )
+        if mode == "strict" and status == "converged":
+            if not evidence_at_least(per_level_evidence[k], "verified_empirical"):
+                status = "marginal"
+                per_level_warnings[k].append(
+                    "strict_mode_downgrade_insufficient_evidence"
+                )
+        per_level_status.append(status)
+    return per_level_status
+
+
+def _aggregate_worst(verdicts: list[LevelVerdict]) -> tuple[int, Status]:
+    """Return the index and Status of the worst-ranked level verdict."""
+    worst_rank = -1
+    worst_idx = 0
+    for k, v in enumerate(verdicts):
+        r = _status_rank(v.status)
+        if r > worst_rank:
+            worst_rank = r
+            worst_idx = k
+    return worst_idx, verdicts[worst_idx].status
 
 
 def estimate_convergence(qubit: Any, **kwargs: Any) -> ConvergenceReport:

--- a/scqubits/core/convergence.py
+++ b/scqubits/core/convergence.py
@@ -1,0 +1,700 @@
+# convergence.py
+#
+# This file is part of scqubits: a Python package for superconducting qubits,
+# Quantum 5, 583 (2021). https://quantum-journal.org/papers/q-2021-11-17-583/
+#
+#    Copyright (c) 2019 and later, Jens Koch and Peter Groszkowski
+#    All rights reserved.
+#
+#    This source code is licensed under the BSD-style license found in the
+#    LICENSE file in the root directory of this source tree.
+############################################################################
+"""ConvergenceCheckable mixin and the energy-channel verified-refinement engine.
+
+PR-1 scope: a concrete qubit that adds ``ConvergenceCheckable`` to its MRO and
+declares ``_convergence_axes`` gains an :meth:`estimate_convergence` method
+returning a :class:`~scqubits.core.convergence_report.ConvergenceReport`.
+Only the energy sub-channel is implemented here; PR-2 adds wavefunctions and
+matrix elements, PR-3 adds coherence.
+
+The mixin's refinement engine clones the qubit, bumps a cutoff axis by a
+step, re-diagonalises, and compares cluster-matched eigenvalues. Cheap-mode
+diagnostics never claim ``converged`` (per the published design specification).
+"""
+
+from __future__ import annotations
+
+import copy
+
+from typing import Any, Optional, Sequence
+
+import numpy as np
+import numpy.typing as npt
+
+import scqubits.utils.convergence_utils as cutils
+
+from scqubits import settings
+from scqubits.core.convergence_report import (
+    ConvergenceReport,
+    Evidence,
+    ImplementationAudit,
+    LevelVerdict,
+    Status,
+    TruncationChannel,
+    evidence_at_least,
+)
+
+
+class ConvergenceCheckable:
+    """Mixin providing :meth:`estimate_convergence` for qubit classes.
+
+    Concrete qubits opt in by:
+
+    1. adding this class to their MRO,
+    2. declaring ``_convergence_axes`` (a tuple of attribute names that name
+       the truncation knobs to refine), and
+    3. optionally overriding the hooks below.
+
+    The mixin owns the refinement engine; per-class hooks supply the small
+    amount of qubit-specific knowledge needed (step size, channel label,
+    cheap diagnostic).
+    """
+
+    # Per-class override. A class attribute is the common case (Transmon:
+    # ``("ncut",)``); ``Circuit`` will use a ``@property`` to introspect its
+    # dynamic ``cutoff_n_*`` / ``cutoff_ext_*`` attributes.
+    _convergence_axes: tuple[str, ...] = ()
+
+    # ------------------------------------------------------------------ hooks
+    # Per-class overrides. Defaults are reasonable for transmon-like
+    # single-knob qubits; multi-axis qubits override.
+
+    def _convergence_step(self, axis: str) -> int:
+        """Return the refinement step (axis units) for ``axis``.
+
+        Default: ``max(4, current_value // 4)``. Concrete qubits override
+        if a different heuristic better matches their convergence law.
+        """
+        current = getattr(self, axis)
+        return max(4, current // 4)
+
+    def _convergence_truncation_channel(self, axis: str) -> TruncationChannel:
+        """Return the physical channel label for ``axis``.
+
+        Defaults to ``"charge"``. Concrete qubits override for HO bases
+        (``"HO_phi"``), finite-difference grids (``"FD_grid"``), etc.
+        """
+        return "charge"
+
+    def _convergence_boundary_diagnostic(
+        self, esys: tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]], axis: str
+    ) -> Optional[npt.NDArray[np.float64]]:
+        """Return a per-level cheap boundary-amplitude diagnostic.
+
+        For Transmon: ``|c_{-ncut, k}|^2 + |c_{+ncut, k}|^2`` for each kept
+        level ``k``. Returns ``None`` if no cheap diagnostic is available
+        for this axis; quick mode then falls back to ``unverified``.
+        """
+        return None
+
+    # ----------------------------------------------------------------- public
+
+    def estimate_convergence(
+        self,
+        n_levels: int = 6,
+        mode: str = "verify",
+        scope: str = "absolute",
+        target_abs_GHz: Optional[float] = None,
+        target_gap_rel: float = 1e-3,
+        g_floor_GHz: float = 1e-3,
+        include_derived: bool = False,
+        derived_quantities: Optional[Sequence[str]] = None,
+        refinement: str = "one_step",
+    ) -> ConvergenceReport:
+        """Estimate the convergence of the lowest ``n_levels`` eigenvalues.
+
+        Parameters
+        ----------
+        n_levels:
+            Number of lowest eigenvalues to assess.
+        mode:
+            One of ``"quick"`` (cheap diagnostics only, no extra
+            diagonalisations), ``"verify"`` (one refinement at a bumped
+            cutoff; default), or ``"strict"`` (ratio test across two
+            successive refinements).
+        scope:
+            ``"absolute"`` (verdict applied to ``abs_err_est_GHz``) or
+            ``"observed_gap_scale"`` (verdict applied to error normalised
+            by the local isolation gap).
+        target_abs_GHz:
+            Required for absolute-scope status assignment. If ``None``,
+            the report still includes ``abs_err_est_GHz`` per level but
+            statuses default to ``"unverified"``.
+        target_gap_rel:
+            Threshold for the observed-gap scope (default ``1e-3``).
+        g_floor_GHz:
+            Floor on the local isolation gap (default ``1e-3`` GHz = 1 MHz)
+            to avoid divide-by-tiny-numbers when the gap is very small.
+        include_derived:
+            PR-1: ignored; raises ``NotImplementedError`` if set to True
+            in this PR (the wavefunctions/matrix-elements/coherence
+            channels arrive in PR-2 and PR-3).
+        derived_quantities:
+            PR-1: ignored.
+        refinement:
+            ``"one_step"`` for verify mode; ``"ratio_test"`` for strict
+            mode. Coerced to match ``mode`` if inconsistent.
+
+        Returns
+        -------
+        :class:`~scqubits.core.convergence_report.ConvergenceReport`
+        """
+        # -------- input validation
+        if mode not in ("quick", "verify", "strict"):
+            raise ValueError(
+                f"mode must be 'quick', 'verify', or 'strict'; got {mode!r}"
+            )
+        if scope not in ("absolute", "observed_gap_scale"):
+            raise ValueError(
+                f"scope must be 'absolute' or 'observed_gap_scale'; got {scope!r}"
+            )
+        if refinement not in ("one_step", "ratio_test"):
+            raise ValueError(
+                f"refinement must be 'one_step' or 'ratio_test'; " f"got {refinement!r}"
+            )
+        if include_derived:
+            raise NotImplementedError(
+                "include_derived=True is not yet available in this version. "
+                "Wavefunctions and matrix elements arrive in PR-2; coherence "
+                "in PR-3."
+            )
+        if not self._convergence_axes:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not declare _convergence_axes; "
+                "convergence checking is not implemented for this class."
+            )
+
+        # In strict mode, ratio_test is the implied refinement.
+        if mode == "strict" and refinement == "one_step":
+            refinement = "ratio_test"
+
+        # -------- diagonalise at the current cutoff
+        # Buffer one extra level so the topmost reported level still has an
+        # upper gap available for the observed-gap-scale denominator.
+        n_buffer = 1 if scope == "observed_gap_scale" else 0
+        n_eigs = n_levels + n_buffer
+        evals_n0, evecs_n0 = self.eigensys(evals_count=n_eigs)  # type: ignore[attr-defined]
+
+        # -------- dispatch by mode
+        if mode == "quick":
+            return self._convergence_quick(
+                evals_n0=evals_n0,
+                evecs_n0=evecs_n0,
+                n_levels=n_levels,
+                scope=scope,
+                target_abs_GHz=target_abs_GHz,
+                target_gap_rel=target_gap_rel,
+                g_floor_GHz=g_floor_GHz,
+            )
+        # verify / strict
+        return self._convergence_refine(
+            evals_n0=evals_n0,
+            evecs_n0=evecs_n0,
+            n_levels=n_levels,
+            n_buffer=n_buffer,
+            mode=mode,
+            scope=scope,
+            target_abs_GHz=target_abs_GHz,
+            target_gap_rel=target_gap_rel,
+            g_floor_GHz=g_floor_GHz,
+            refinement=refinement,
+        )
+
+    # ------------------------------------------------------------ engine helpers
+
+    def _convergence_clone_at(
+        self, axis_values: dict[str, int]
+    ) -> "ConvergenceCheckable":
+        """Return a deep-copy of this qubit with the named axes set to new values.
+
+        Uses ``copy.deepcopy`` plus attribute assignment. scqubits'
+        ``WatchedProperty`` descriptors invalidate any internal caches on
+        attribute change, so the clone re-computes the spectrum from scratch.
+        """
+        clone = copy.deepcopy(self)
+        for axis, value in axis_values.items():
+            setattr(clone, axis, value)
+        return clone
+
+    def _convergence_audit(
+        self,
+        n_levels: int,
+        n_buffer: int,
+        mode: str,
+        refinement: str,
+    ) -> ImplementationAudit:
+        """Construct an :class:`ImplementationAudit` snapshot."""
+        try:
+            from scqubits import __version__ as scq_version
+        except ImportError:  # pragma: no cover -- defensive
+            scq_version = "unknown"
+
+        cutoff_params = {
+            axis: int(getattr(self, axis)) for axis in self._convergence_axes
+        }
+        # Diagonalisation method label: prefer an explicit user setting if
+        # provided, otherwise fall back to a generic "default".
+        diag_method = getattr(self, "evals_method", None) or "default"
+        if not isinstance(diag_method, str):
+            diag_method = getattr(diag_method, "__name__", "callable")
+
+        return ImplementationAudit(
+            scqubits_version=str(scq_version),
+            scqubits_commit=None,
+            qubit_class=type(self).__name__,
+            basis=getattr(self, "_convergence_basis", "auto"),
+            diagonalization_method=str(diag_method),
+            cutoff_parameters=cutoff_params,
+            fd_stencil_order=None,
+            fd_box=None,
+            nonpoly_backend=None,
+            n_levels_requested=n_levels,
+            n_levels_buffer=n_buffer,
+            mode=mode,  # type: ignore[arg-type]
+            refinement=refinement,  # type: ignore[arg-type]
+        )
+
+    # ------------------------------------------------------------ mode handlers
+
+    def _convergence_quick(
+        self,
+        evals_n0: npt.NDArray[np.float64],
+        evecs_n0: npt.NDArray[np.float64],
+        n_levels: int,
+        scope: str,
+        target_abs_GHz: Optional[float],
+        target_gap_rel: float,
+        g_floor_GHz: float,
+    ) -> ConvergenceReport:
+        """Quick-mode report: cheap boundary diagnostic only.
+
+        Per the published design, quick mode never returns ``converged``;
+        the best it can say is ``likely_converged`` based on a cheap
+        boundary-amplitude check.
+        """
+        # We assume a single axis for PR-1 (Transmon ncut). Multi-axis
+        # quick-mode aggregation is straightforward and added with Stage 3.
+        axis = self._convergence_axes[0]
+        boundary_amplitudes = self._convergence_boundary_diagnostic(
+            (evals_n0, evecs_n0), axis
+        )
+        channel: TruncationChannel = self._convergence_truncation_channel(axis)
+
+        per_level: list[LevelVerdict] = []
+        recommendations: list[str] = []
+        # Start worst-tracker at the best possible status; accumulate worse
+        # as levels are inspected.
+        worst_index: int = 0
+        worst_status: Status = "converged"
+
+        # Threshold under which a level is "likely_converged" from quick
+        # diagnostics alone. Conservative -- the published design only
+        # allows quick mode to escape "unverified" in clearly easy regimes.
+        QUICK_BOUNDARY_THRESHOLD = 1e-6
+
+        for k in range(n_levels):
+            warnings: list[str] = []
+            if boundary_amplitudes is None:
+                status: Status = "unverified"
+                ev: Evidence = "unverified"
+                warnings.append("no_boundary_diagnostic_available")
+            elif boundary_amplitudes[k] < QUICK_BOUNDARY_THRESHOLD:
+                status = "likely_converged"
+                ev = "diagnostic"
+            else:
+                status = "unverified"
+                ev = "diagnostic"
+                warnings.append("boundary_amplitude_above_threshold")
+                recommendations.append(
+                    f"level {k}: boundary amplitude {boundary_amplitudes[k]:.2e} "
+                    f"exceeds quick-mode threshold {QUICK_BOUNDARY_THRESHOLD:.0e}; "
+                    f"re-run with mode='verify' to obtain an empirical estimate"
+                )
+
+            per_level.append(
+                LevelVerdict(
+                    level_index=k,
+                    status=status,
+                    status_scope=scope,  # type: ignore[arg-type]
+                    evidence=ev,
+                    abs_err_est_GHz=None,  # quick mode has no error estimate
+                    eps_gap_est=None,
+                    truncation_channel=channel,
+                    estimator_method="boundary_diagnostic",
+                    warnings=tuple(warnings),
+                )
+            )
+
+            # Track worst status for aggregate.
+            if _status_rank(status) > _status_rank(worst_status):
+                worst_status = status
+                worst_index = k
+
+        # If no level escaped "unverified", aggregate is "unverified".
+        if worst_index is None:
+            worst_index = 0
+
+        return ConvergenceReport(
+            per_level=per_level,
+            aggregate_status=worst_status,
+            worst_level=worst_index,
+            channel_breakdown_GHz={},
+            clusters=[(k,) for k in range(n_levels)],
+            recommendations=list(dict.fromkeys(recommendations)),  # dedupe
+            implementation_audit=self._convergence_audit(
+                n_levels=n_levels, n_buffer=0, mode="quick", refinement="one_step"
+            ),
+        )
+
+    def _convergence_refine(
+        self,
+        evals_n0: npt.NDArray[np.float64],
+        evecs_n0: npt.NDArray[np.float64],
+        n_levels: int,
+        n_buffer: int,
+        mode: str,
+        scope: str,
+        target_abs_GHz: Optional[float],
+        target_gap_rel: float,
+        g_floor_GHz: float,
+        refinement: str,
+    ) -> ConvergenceReport:
+        """Verify / strict mode: refine cutoff(s), compare cluster-matched energies."""
+        # For PR-1, we handle exactly one axis. Multi-axis aggregation
+        # (refine one axis at a time, combine absolute errors by triangle
+        # inequality) will be added when Circuit lands in Stage 3.
+        if len(self._convergence_axes) != 1:
+            raise NotImplementedError(
+                "Multi-axis refinement is not yet implemented; only single-axis "
+                "qubits (e.g. Transmon) are supported in this version."
+            )
+        axis = self._convergence_axes[0]
+        step = self._convergence_step(axis)
+        n_eigs = n_levels + n_buffer
+
+        current_value = getattr(self, axis)
+        clone_1 = self._convergence_clone_at({axis: current_value + step})
+        evals_n1, _ = clone_1.eigensys(evals_count=n_eigs)  # type: ignore[attr-defined]
+
+        evals_n2: Optional[npt.NDArray[np.float64]] = None
+        if refinement == "ratio_test":
+            clone_2 = self._convergence_clone_at({axis: current_value + 2 * step})
+            evals_n2, _ = clone_2.eigensys(evals_count=n_eigs)  # type: ignore[attr-defined]
+
+        return self._convergence_build_energy_report(
+            evals_n0=evals_n0[:n_levels],
+            evals_n1=evals_n1[:n_levels],
+            evals_n2=evals_n2[:n_levels] if evals_n2 is not None else None,
+            buffer_n0=evals_n0[n_levels:] if n_buffer > 0 else None,
+            n_levels=n_levels,
+            n_buffer=n_buffer,
+            mode=mode,
+            scope=scope,
+            target_abs_GHz=target_abs_GHz,
+            target_gap_rel=target_gap_rel,
+            g_floor_GHz=g_floor_GHz,
+            refinement=refinement,
+            axis=axis,
+        )
+
+    def _convergence_build_energy_report(
+        self,
+        evals_n0: npt.NDArray[np.float64],
+        evals_n1: npt.NDArray[np.float64],
+        evals_n2: Optional[npt.NDArray[np.float64]],
+        buffer_n0: Optional[npt.NDArray[np.float64]],
+        n_levels: int,
+        n_buffer: int,
+        mode: str,
+        scope: str,
+        target_abs_GHz: Optional[float],
+        target_gap_rel: float,
+        g_floor_GHz: float,
+        refinement: str,
+        axis: str,
+    ) -> ConvergenceReport:
+        """Assemble the LevelVerdicts and the ConvergenceReport from refinement
+        eigenvalues. Shared between verify and strict modes."""
+        channel: TruncationChannel = self._convergence_truncation_channel(axis)
+        cluster_threshold = settings.CONVERGENCE_CLUSTER_RATIO
+        safety_factor = settings.CONVERGENCE_SAFETY_FACTOR
+
+        # Cluster-detect on N0 (the reference / user's current spectrum).
+        clusters = cutils.detect_clusters(
+            evals_n0, gap_ratio_threshold=cluster_threshold
+        )
+        _, cluster_max_diff_n1 = cutils.cluster_safe_match_energies(
+            evals_n0, evals_n1, clusters
+        )
+
+        # Per-level: assign the cluster-level estimate to every member.
+        per_level_estimate = np.empty(n_levels, dtype=np.float64)
+        for cluster_idx, cluster in enumerate(clusters):
+            for k in cluster:
+                per_level_estimate[k] = cluster_max_diff_n1[cluster_idx]
+
+        # Strict mode: ratio test.
+        ratio_per_cluster: Optional[npt.NDArray[np.float64]] = None
+        geometric_tail: Optional[npt.NDArray[np.float64]] = None
+        asymptotic_flag: Optional[npt.NDArray[np.bool_]] = None
+        if refinement == "ratio_test" and evals_n2 is not None:
+            _, cluster_max_diff_n2 = cutils.cluster_safe_match_energies(
+                evals_n1, evals_n2, clusters
+            )
+            ratio_per_cluster = np.divide(
+                cluster_max_diff_n2,
+                cluster_max_diff_n1,
+                out=np.full_like(cluster_max_diff_n1, np.inf),
+                where=cluster_max_diff_n1 > 0,
+            )
+            # Geometric-tail estimate: d0 / (1 - R) when R < 1.
+            geometric_tail = np.where(
+                ratio_per_cluster < 1.0,
+                cluster_max_diff_n1 / np.clip(1.0 - ratio_per_cluster, 1e-30, None),
+                np.inf,
+            )
+            asymptotic_flag = ratio_per_cluster < 1.0
+
+        # If strict-mode geometric tail succeeded, use that as the
+        # estimate; otherwise stick with safety_factor * d0.
+        per_level_abs_err = np.empty(n_levels, dtype=np.float64)
+        per_level_evidence: list[Evidence] = []
+        per_level_estimator_method: list[str] = []
+        per_level_warnings: list[list[str]] = [[] for _ in range(n_levels)]
+
+        for cluster_idx, cluster in enumerate(clusters):
+            if refinement == "ratio_test" and geometric_tail is not None:
+                if asymptotic_flag is not None and asymptotic_flag[cluster_idx]:
+                    est = float(geometric_tail[cluster_idx])
+                    ev: Evidence = "calibrated"
+                    method = "ratio_test"
+                else:
+                    est = float(safety_factor * cluster_max_diff_n1[cluster_idx])
+                    ev = "verified_empirical"
+                    method = "ratio_test_failed_fallback_one_step"
+                    for k in cluster:
+                        per_level_warnings[k].append("ratio_test_not_asymptotic")
+            else:
+                est = float(safety_factor * cluster_max_diff_n1[cluster_idx])
+                ev = "verified_empirical"
+                method = "one_step"
+
+            for k in cluster:
+                per_level_abs_err[k] = est
+                per_level_evidence.append(ev)
+                per_level_estimator_method.append(method)
+
+        # Observed-gap scope: compute local isolation gaps from N0 spectrum.
+        eps_gap_est: list[Optional[float]]
+        if scope == "observed_gap_scale":
+            eps_gap_est = []
+            for k in range(n_levels):
+                gap = _local_isolation_gap(
+                    evals_n0=evals_n0,
+                    buffer_n0=buffer_n0,
+                    k=k,
+                    n_levels=n_levels,
+                    g_floor=g_floor_GHz,
+                )
+                if gap is None:
+                    # Topmost level without buffer: cannot compute upper gap.
+                    eps_gap_est.append(None)
+                    per_level_warnings[k].append("upper_gap_unavailable")
+                else:
+                    eps_gap_est.append(float(per_level_abs_err[k] / gap))
+        else:
+            eps_gap_est = [None] * n_levels
+
+        # Assign status per level based on chosen scope and target.
+        per_level_status: list[Status] = []
+        for k in range(n_levels):
+            status = _assign_status(
+                abs_err_est=float(per_level_abs_err[k]),
+                eps_gap_est=eps_gap_est[k],
+                scope=scope,
+                target_abs_GHz=target_abs_GHz,
+                target_gap_rel=target_gap_rel,
+            )
+            # Strict mode downgrades any status weaker than verified_empirical.
+            if mode == "strict" and status == "converged":
+                if not evidence_at_least(per_level_evidence[k], "verified_empirical"):
+                    status = "marginal"
+                    per_level_warnings[k].append(
+                        "strict_mode_downgrade_insufficient_evidence"
+                    )
+            per_level_status.append(status)
+
+        # Build LevelVerdicts.
+        per_level_verdicts: list[LevelVerdict] = []
+        for k in range(n_levels):
+            per_level_verdicts.append(
+                LevelVerdict(
+                    level_index=k,
+                    status=per_level_status[k],
+                    status_scope=scope,  # type: ignore[arg-type]
+                    evidence=per_level_evidence[k],
+                    abs_err_est_GHz=float(per_level_abs_err[k]),
+                    eps_gap_est=eps_gap_est[k],
+                    truncation_channel=channel,
+                    estimator_method=per_level_estimator_method[k],
+                    warnings=tuple(per_level_warnings[k]),
+                )
+            )
+
+        # Aggregate worst status.
+        worst_rank = -1
+        worst_idx = 0
+        for k, v in enumerate(per_level_verdicts):
+            r = _status_rank(v.status)
+            if r > worst_rank:
+                worst_rank = r
+                worst_idx = k
+        aggregate_status: Status = per_level_verdicts[worst_idx].status
+
+        # Recommendations.
+        recommendations: list[str] = []
+        if any(v.status == "underconverged" for v in per_level_verdicts):
+            current_value = int(getattr(self, axis))
+            step = self._convergence_step(axis)
+            recommendations.append(
+                f"increase {axis} from {current_value} to at least "
+                f"{current_value + step} and re-run; the worst-level "
+                f"estimate exceeded the target threshold"
+            )
+        if (
+            scope == "absolute"
+            and target_abs_GHz is None
+            and any(v.status == "unverified" for v in per_level_verdicts)
+        ):
+            recommendations.append(
+                "supply target_abs_GHz for an automatic status assignment "
+                "in absolute scope; report currently exposes abs_err_est_GHz "
+                "per level without thresholding"
+            )
+
+        return ConvergenceReport(
+            per_level=per_level_verdicts,
+            aggregate_status=aggregate_status,
+            worst_level=worst_idx,
+            channel_breakdown_GHz={
+                channel: float(np.max(per_level_abs_err)),
+            },
+            clusters=clusters,
+            recommendations=recommendations,
+            implementation_audit=self._convergence_audit(
+                n_levels=n_levels,
+                n_buffer=n_buffer,
+                mode=mode,
+                refinement=refinement,
+            ),
+        )
+
+
+# ------------------------------------------------------------ module helpers
+
+
+_STATUS_RANK: dict[Status, int] = {
+    "converged": 0,
+    "likely_converged": 1,
+    "marginal": 2,
+    "underconverged": 3,
+    "unverified": 4,
+}
+
+
+def _status_rank(status: Status) -> int:
+    """Rank for aggregating worst per-level status; higher is worse."""
+    return _STATUS_RANK[status]
+
+
+def _local_isolation_gap(
+    evals_n0: npt.NDArray[np.float64],
+    buffer_n0: Optional[npt.NDArray[np.float64]],
+    k: int,
+    n_levels: int,
+    g_floor: float,
+) -> Optional[float]:
+    """Compute the local isolation gap for level ``k``.
+
+    Per the design specification:
+
+    - k == 0: ``E_1 - E_0``
+    - 1 <= k <= n_levels - 2: ``min(E_k - E_{k-1}, E_{k+1} - E_k)``
+    - k == n_levels - 1: upper gap available only if ``buffer_n0`` is
+      supplied; otherwise return ``None``.
+
+    The returned gap is floored at ``g_floor``.
+    """
+    if k == 0:
+        if n_levels < 2:
+            return None
+        return max(float(evals_n0[1] - evals_n0[0]), g_floor)
+    if k < n_levels - 1:
+        return max(
+            min(
+                float(evals_n0[k] - evals_n0[k - 1]),
+                float(evals_n0[k + 1] - evals_n0[k]),
+            ),
+            g_floor,
+        )
+    # k == n_levels - 1
+    if buffer_n0 is None or len(buffer_n0) == 0:
+        return None
+    return max(
+        min(
+            float(evals_n0[k] - evals_n0[k - 1]),
+            float(buffer_n0[0] - evals_n0[k]),
+        ),
+        g_floor,
+    )
+
+
+def _assign_status(
+    abs_err_est: float,
+    eps_gap_est: Optional[float],
+    scope: str,
+    target_abs_GHz: Optional[float],
+    target_gap_rel: float,
+) -> Status:
+    """Assign a Status based on the configured scope and target."""
+    if scope == "absolute":
+        if target_abs_GHz is None:
+            return "unverified"
+        if abs_err_est < target_abs_GHz:
+            return "converged"
+        if abs_err_est < 10.0 * target_abs_GHz:
+            return "marginal"
+        return "underconverged"
+    # observed_gap_scale
+    if eps_gap_est is None:
+        return "unverified"
+    if eps_gap_est < target_gap_rel:
+        return "converged"
+    if eps_gap_est < 10.0 * target_gap_rel:
+        return "marginal"
+    return "underconverged"
+
+
+def estimate_convergence(qubit: Any, **kwargs: Any) -> ConvergenceReport:
+    """Convenience top-level shim: forwards to ``qubit.estimate_convergence(...)``.
+
+    Raises ``TypeError`` if the qubit does not subclass
+    :class:`ConvergenceCheckable`.
+    """
+    if not isinstance(qubit, ConvergenceCheckable):
+        raise TypeError(
+            f"{type(qubit).__name__} does not implement convergence checking. "
+            "Subclasses of ConvergenceCheckable in this version: Transmon "
+            "(further qubits land in subsequent PRs)."
+        )
+    return qubit.estimate_convergence(**kwargs)

--- a/scqubits/core/convergence.py
+++ b/scqubits/core/convergence.py
@@ -18,7 +18,7 @@ Only the energy sub-channel is implemented here; PR-2 adds wavefunctions and
 matrix elements, PR-3 adds coherence.
 
 The mixin's refinement engine clones the qubit, bumps a cutoff axis by a
-step, re-diagonalises, and compares cluster-matched eigenvalues. Cheap-mode
+step, re-diagonalizes, and compares cluster-matched eigenvalues. Cheap-mode
 diagnostics never claim ``converged`` (per the published design specification).
 """
 
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import copy
 
-from typing import Any, Optional, Sequence
+from typing import Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -88,7 +88,7 @@ class ConvergenceCheckable:
 
     def _convergence_boundary_diagnostic(
         self, esys: tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]], axis: str
-    ) -> Optional[npt.NDArray[np.float64]]:
+    ) -> npt.NDArray[np.float64] | None:
         """Return a per-level cheap boundary-amplitude diagnostic.
 
         For Transmon: ``|c_{-ncut, k}|^2 + |c_{+ncut, k}|^2`` for each kept
@@ -104,11 +104,11 @@ class ConvergenceCheckable:
         n_levels: int = 6,
         mode: str = "verify",
         scope: str = "absolute",
-        target_abs_GHz: Optional[float] = None,
+        target_abs_GHz: float | None = None,
         target_gap_rel: float = 1e-3,
         g_floor_GHz: float = 1e-3,
         include_derived: bool = False,
-        derived_quantities: Optional[Sequence[str]] = None,
+        derived_quantities: Sequence[str] | None = None,
         refinement: str = "one_step",
     ) -> ConvergenceReport:
         """Estimate the convergence of the lowest ``n_levels`` eigenvalues.
@@ -119,12 +119,12 @@ class ConvergenceCheckable:
             Number of lowest eigenvalues to assess.
         mode:
             One of ``"quick"`` (cheap diagnostics only, no extra
-            diagonalisations), ``"verify"`` (one refinement at a bumped
+            diagonalizations), ``"verify"`` (one refinement at a bumped
             cutoff; default), or ``"strict"`` (ratio test across two
             successive refinements).
         scope:
             ``"absolute"`` (verdict applied to ``abs_err_est_GHz``) or
-            ``"observed_gap_scale"`` (verdict applied to error normalised
+            ``"observed_gap_scale"`` (verdict applied to error normalized
             by the local isolation gap).
         target_abs_GHz:
             Required for absolute-scope status assignment. If ``None``,
@@ -178,7 +178,7 @@ class ConvergenceCheckable:
         if mode == "strict" and refinement == "one_step":
             refinement = "ratio_test"
 
-        # -------- diagonalise at the current cutoff
+        # -------- diagonalize at the current cutoff
         # Buffer one extra level so the topmost reported level still has an
         # upper gap available for the observed-gap-scale denominator.
         n_buffer = 1 if scope == "observed_gap_scale" else 0
@@ -242,7 +242,7 @@ class ConvergenceCheckable:
         cutoff_params = {
             axis: int(getattr(self, axis)) for axis in self._convergence_axes
         }
-        # Diagonalisation method label: prefer an explicit user setting if
+        # Diagonalization method label: prefer an explicit user setting if
         # provided, otherwise fall back to a generic "default".
         diag_method = getattr(self, "evals_method", None) or "default"
         if not isinstance(diag_method, str):
@@ -272,7 +272,7 @@ class ConvergenceCheckable:
         evecs_n0: npt.NDArray[np.float64],
         n_levels: int,
         scope: str,
-        target_abs_GHz: Optional[float],
+        target_abs_GHz: float | None,
         target_gap_rel: float,
         g_floor_GHz: float,
     ) -> ConvergenceReport:
@@ -364,7 +364,7 @@ class ConvergenceCheckable:
         n_buffer: int,
         mode: str,
         scope: str,
-        target_abs_GHz: Optional[float],
+        target_abs_GHz: float | None,
         target_gap_rel: float,
         g_floor_GHz: float,
         refinement: str,
@@ -386,7 +386,7 @@ class ConvergenceCheckable:
         clone_1 = self._convergence_clone_at({axis: current_value + step})
         evals_n1, _ = clone_1.eigensys(evals_count=n_eigs)  # type: ignore[attr-defined]
 
-        evals_n2: Optional[npt.NDArray[np.float64]] = None
+        evals_n2: npt.NDArray[np.float64] | None = None
         if refinement == "ratio_test":
             clone_2 = self._convergence_clone_at({axis: current_value + 2 * step})
             evals_n2, _ = clone_2.eigensys(evals_count=n_eigs)  # type: ignore[attr-defined]
@@ -411,13 +411,13 @@ class ConvergenceCheckable:
         self,
         evals_n0: npt.NDArray[np.float64],
         evals_n1: npt.NDArray[np.float64],
-        evals_n2: Optional[npt.NDArray[np.float64]],
-        buffer_n0: Optional[npt.NDArray[np.float64]],
+        evals_n2: npt.NDArray[np.float64] | None,
+        buffer_n0: npt.NDArray[np.float64] | None,
         n_levels: int,
         n_buffer: int,
         mode: str,
         scope: str,
-        target_abs_GHz: Optional[float],
+        target_abs_GHz: float | None,
         target_gap_rel: float,
         g_floor_GHz: float,
         refinement: str,
@@ -444,9 +444,9 @@ class ConvergenceCheckable:
                 per_level_estimate[k] = cluster_max_diff_n1[cluster_idx]
 
         # Strict mode: ratio test.
-        ratio_per_cluster: Optional[npt.NDArray[np.float64]] = None
-        geometric_tail: Optional[npt.NDArray[np.float64]] = None
-        asymptotic_flag: Optional[npt.NDArray[np.bool_]] = None
+        ratio_per_cluster: npt.NDArray[np.float64] | None = None
+        geometric_tail: npt.NDArray[np.float64] | None = None
+        asymptotic_flag: npt.NDArray[np.bool_] | None = None
         if refinement == "ratio_test" and evals_n2 is not None:
             _, cluster_max_diff_n2 = cutils.cluster_safe_match_energies(
                 evals_n1, evals_n2, clusters
@@ -495,7 +495,7 @@ class ConvergenceCheckable:
                 per_level_estimator_method.append(method)
 
         # Observed-gap scope: compute local isolation gaps from N0 spectrum.
-        eps_gap_est: list[Optional[float]]
+        eps_gap_est: list[float | None]
         if scope == "observed_gap_scale":
             eps_gap_est = []
             for k in range(n_levels):
@@ -619,11 +619,11 @@ def _status_rank(status: Status) -> int:
 
 def _local_isolation_gap(
     evals_n0: npt.NDArray[np.float64],
-    buffer_n0: Optional[npt.NDArray[np.float64]],
+    buffer_n0: npt.NDArray[np.float64] | None,
     k: int,
     n_levels: int,
     g_floor: float,
-) -> Optional[float]:
+) -> float | None:
     """Compute the local isolation gap for level ``k``.
 
     Per the design specification:
@@ -661,9 +661,9 @@ def _local_isolation_gap(
 
 def _assign_status(
     abs_err_est: float,
-    eps_gap_est: Optional[float],
+    eps_gap_est: float | None,
     scope: str,
-    target_abs_GHz: Optional[float],
+    target_abs_GHz: float | None,
     target_gap_rel: float,
 ) -> Status:
     """Assign a Status based on the configured scope and target."""

--- a/scqubits/core/convergence_report.py
+++ b/scqubits/core/convergence_report.py
@@ -21,7 +21,7 @@ explicit evidence label to every numerical conclusion.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal, Optional
+from typing import Literal
 
 Status = Literal[
     "converged", "likely_converged", "marginal", "underconverged", "unverified"
@@ -35,7 +35,7 @@ diagnostics; an unqualified ``converged`` always implies at least
 
 StatusScope = Literal["absolute", "observed_gap_scale"]
 """Whether the convergence threshold was applied to an absolute energy error
-(in GHz) or to an error normalised by an observed local spectral gap.
+(in GHz) or to an error normalized by an observed local spectral gap.
 
 The basis-parameter scale (e.g. fluxonium ``omega_LC``) is intentionally not a
 reporting scope -- see the published design specification for the rationale.
@@ -95,8 +95,8 @@ class LevelVerdict:
     status: Status
     status_scope: StatusScope
     evidence: Evidence
-    abs_err_est_GHz: Optional[float]
-    eps_gap_est: Optional[float]
+    abs_err_est_GHz: float | None
+    eps_gap_est: float | None
     transition_err_est_GHz: dict[tuple[int, int], float] = field(default_factory=dict)
     truncation_channel: TruncationChannel = "charge"
     estimator_method: str = "one_step"
@@ -113,14 +113,14 @@ class ImplementationAudit:
     """
 
     scqubits_version: str
-    scqubits_commit: Optional[str]
+    scqubits_commit: str | None
     qubit_class: str
     basis: str
     diagonalization_method: str
     cutoff_parameters: dict[str, int]
-    fd_stencil_order: Optional[int]
-    fd_box: Optional[tuple[float, float]]
-    nonpoly_backend: Optional[str]
+    fd_stencil_order: int | None
+    fd_box: tuple[float, float] | None
+    nonpoly_backend: str | None
     n_levels_requested: int
     n_levels_buffer: int
     mode: Literal["quick", "verify", "strict"]
@@ -138,12 +138,12 @@ class ConvergenceReport:
 
     per_level: list[LevelVerdict]
     aggregate_status: Status
-    worst_level: Optional[int]
+    worst_level: int | None
     channel_breakdown_GHz: dict[str, float]
     clusters: list[tuple[int, ...]]
     recommendations: list[str]
     implementation_audit: ImplementationAudit
-    derived: Optional[dict[str, "ConvergenceReport"]] = None
+    derived: dict[str, "ConvergenceReport"] | None = None
 
 
 # Ordered list used by callers wanting to filter on minimum evidence strength.

--- a/scqubits/core/convergence_report.py
+++ b/scqubits/core/convergence_report.py
@@ -1,0 +1,166 @@
+# convergence_report.py
+#
+# This file is part of scqubits: a Python package for superconducting qubits,
+# Quantum 5, 583 (2021). https://quantum-journal.org/papers/q-2021-11-17-583/
+#
+#    Copyright (c) 2019 and later, Jens Koch and Peter Groszkowski
+#    All rights reserved.
+#
+#    This source code is licensed under the BSD-style license found in the
+#    LICENSE file in the root directory of this source tree.
+############################################################################
+"""Verdict and report data classes for the convergence-diagnostics framework.
+
+The three frozen dataclasses defined here form the return type of
+:meth:`scqubits.core.convergence.ConvergenceCheckable.estimate_convergence`.
+The schema deliberately separates true (unknown) error from estimated error,
+separates absolute from observed-gap-scale error metrics, and attaches an
+explicit evidence label to every numerical conclusion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+Status = Literal[
+    "converged", "likely_converged", "marginal", "underconverged", "unverified"
+]
+"""Convergence status, in order from best to worst.
+
+``likely_converged`` is reserved for quick-mode reports based only on cheap
+diagnostics; an unqualified ``converged`` always implies at least
+``verified_empirical`` evidence.
+"""
+
+StatusScope = Literal["absolute", "observed_gap_scale"]
+"""Whether the convergence threshold was applied to an absolute energy error
+(in GHz) or to an error normalised by an observed local spectral gap.
+
+The basis-parameter scale (e.g. fluxonium ``omega_LC``) is intentionally not a
+reporting scope -- see the published design specification for the rationale.
+"""
+
+Evidence = Literal[
+    "certified",
+    "verified_empirical",
+    "calibrated",
+    "perturbative",
+    "diagnostic",
+    "unverified",
+]
+"""Evidence label, ordered from strongest to weakest.
+
+Meanings:
+
+- ``certified``: theorem-level bound with all hypotheses checked at runtime.
+- ``verified_empirical``: refinement or cross-representation comparison with
+  a ratio, asymptoticity, or stability check.
+- ``calibrated``: estimator whose mapping to true error has been measured on
+  a calibration grid covering the stated regime.
+- ``perturbative``: derivation from perturbation theory or a block-resolvent
+  approximation with unverified runtime hypotheses.
+- ``diagnostic``: useful signal of possible failure, not an estimate of the
+  error itself.
+- ``unverified``: inputs unavailable, assumptions failed, or estimator
+  inapplicable.
+"""
+
+TruncationChannel = Literal[
+    "charge",
+    "HO_phi",
+    "HO_theta",
+    "FD_grid",
+    "coordinate",
+    "composite",
+]
+"""Physical truncation channel responsible for a (sub-)report.
+
+Reserved for actual error sources (which basis is being truncated), distinct
+from ``estimator_method`` (how the error was estimated) and ``warnings`` (what
+caveats accompany the verdict). The three vocabularies are disjoint by design.
+"""
+
+
+@dataclass(frozen=True)
+class LevelVerdict:
+    """Per-level convergence verdict.
+
+    All numerical fields suffixed ``_est`` are computed estimates, not the
+    unknown true error. ``transition_err_est_GHz`` keys are pairs
+    ``(i, j)`` for the transition ``i -> j``.
+    """
+
+    level_index: int
+    status: Status
+    status_scope: StatusScope
+    evidence: Evidence
+    abs_err_est_GHz: Optional[float]
+    eps_gap_est: Optional[float]
+    transition_err_est_GHz: dict[tuple[int, int], float] = field(default_factory=dict)
+    truncation_channel: TruncationChannel = "charge"
+    estimator_method: str = "one_step"
+    warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ImplementationAudit:
+    """Snapshot of the implementation pathway diagnosed by a report.
+
+    Recorded so that warnings and recommendations remain tied to the backend
+    they were derived from; a future change in scqubits' Hamiltonian
+    construction does not silently invalidate previous reports.
+    """
+
+    scqubits_version: str
+    scqubits_commit: Optional[str]
+    qubit_class: str
+    basis: str
+    diagonalization_method: str
+    cutoff_parameters: dict[str, int]
+    fd_stencil_order: Optional[int]
+    fd_box: Optional[tuple[float, float]]
+    nonpoly_backend: Optional[str]
+    n_levels_requested: int
+    n_levels_buffer: int
+    mode: Literal["quick", "verify", "strict"]
+    refinement: Literal["one_step", "ratio_test"]
+
+
+@dataclass(frozen=True)
+class ConvergenceReport:
+    """Structured convergence diagnostic for a qubit's lowest levels.
+
+    The ``derived`` field is reserved for sub-reports (currently only used
+    in later PRs for matrix-element and coherence sub-channels, and in a
+    future HilbertSpace-level extension to compose per-subsystem reports).
+    """
+
+    per_level: list[LevelVerdict]
+    aggregate_status: Status
+    worst_level: Optional[int]
+    channel_breakdown_GHz: dict[str, float]
+    clusters: list[tuple[int, ...]]
+    recommendations: list[str]
+    implementation_audit: ImplementationAudit
+    derived: Optional[dict[str, "ConvergenceReport"]] = None
+
+
+# Ordered list used by callers wanting to filter on minimum evidence strength.
+EVIDENCE_ORDER: tuple[Evidence, ...] = (
+    "certified",
+    "verified_empirical",
+    "calibrated",
+    "perturbative",
+    "diagnostic",
+    "unverified",
+)
+
+
+def evidence_at_least(actual: Evidence, minimum: Evidence) -> bool:
+    """Return True if ``actual`` is at least as strong as ``minimum``.
+
+    Used by ``mode='strict'`` to gate which evidence levels may still claim
+    ``converged`` status.
+    """
+    return EVIDENCE_ORDER.index(actual) <= EVIDENCE_ORDER.index(minimum)

--- a/scqubits/core/transmon.py
+++ b/scqubits/core/transmon.py
@@ -153,7 +153,7 @@ class Transmon(
     def _convergence_truncation_channel(self, axis: str) -> TruncationChannel:
         """Report the ``charge`` truncation channel for ``ncut``.
 
-        Override of the default mixin behaviour; explicit so the reported
+        Override of the default mixin behavior; explicit so the reported
         channel is unambiguous even if the mixin default changes.
         """
         return "charge"

--- a/scqubits/core/transmon.py
+++ b/scqubits/core/transmon.py
@@ -35,6 +35,8 @@ import scqubits.io_utils.fileio_serializers as serializers
 import scqubits.utils.plot_defaults as defaults
 import scqubits.utils.plotting as plot
 
+from scqubits.core.convergence import ConvergenceCheckable
+from scqubits.core.convergence_report import TruncationChannel
 from scqubits.core.discretization import Grid1d
 from scqubits.core.noise import NoisySystem
 from scqubits.core.storage import WaveFunction
@@ -46,7 +48,9 @@ TransitionsTuple = tuple[Transition, ...]
 # Cooper pair box / transmon
 
 
-class Transmon(base.QubitBaseClass1d, serializers.Serializable, NoisySystem):
+class Transmon(
+    base.QubitBaseClass1d, serializers.Serializable, NoisySystem, ConvergenceCheckable
+):
     r"""Class for the Cooper-pair-box and transmon qubit.
 
     The Hamiltonian is represented in dense form in the number basis,
@@ -85,6 +89,13 @@ class Transmon(base.QubitBaseClass1d, serializers.Serializable, NoisySystem):
     EC = descriptors.WatchedProperty(float, "QUANTUMSYSTEM_UPDATE")
     ng = descriptors.WatchedProperty(float, "QUANTUMSYSTEM_UPDATE")
     ncut = descriptors.WatchedProperty(int, "QUANTUMSYSTEM_UPDATE")
+
+    # Convergence-diagnostics integration (see scqubits.core.convergence).
+    # The single truncation axis is ``ncut``; the kept Hilbert space has
+    # dimension ``2 * ncut + 1`` charge states. The basis label and channel
+    # are reported in the audit and per-level verdict respectively.
+    _convergence_axes: tuple[str, ...] = ("ncut",)
+    _convergence_basis: str = "charge"
 
     def __init__(
         self,
@@ -136,6 +147,42 @@ class Transmon(base.QubitBaseClass1d, serializers.Serializable, NoisySystem):
         noise_channels = cls.supported_noise_channels()
         noise_channels.remove("t1_charge_impedance")
         return noise_channels
+
+    # ----- Convergence-diagnostics hooks ----------------------------------------------
+
+    def _convergence_truncation_channel(self, axis: str) -> TruncationChannel:
+        """Report the ``charge`` truncation channel for ``ncut``.
+
+        Override of the default mixin behaviour; explicit so the reported
+        channel is unambiguous even if the mixin default changes.
+        """
+        return "charge"
+
+    def _convergence_boundary_diagnostic(
+        self,
+        esys: tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]],
+        axis: str,
+    ) -> npt.NDArray[np.float64] | None:
+        """Per-level boundary-amplitude cheap diagnostic for ``ncut``.
+
+        Returns ``|c_{-ncut, k}|^2 + |c_{+ncut, k}|^2`` per kept level
+        ``k``. In the charge basis, large boundary amplitudes signal that
+        the truncated eigenstate has appreciable support at the edge of
+        the kept space and is therefore suspect; quick mode promotes a
+        level out of ``unverified`` only when this signal is well below a
+        small threshold.
+
+        Returns ``None`` if ``axis`` is not ``"ncut"`` (defensive; the
+        mixin only invokes this for declared axes).
+        """
+        if axis != "ncut":
+            return None
+        _, evecs = esys
+        # Eigenvector matrix has shape (2*ncut + 1, evals_count); row 0 is
+        # charge -ncut, row 2*ncut is charge +ncut. ``evecs[:, k]`` is the
+        # k-th eigenvector.
+        boundary_sq = np.abs(evecs[0, :]) ** 2 + np.abs(evecs[-1, :]) ** 2
+        return boundary_sq.astype(np.float64)
 
     def _hamiltonian_diagonal(self) -> npt.NDArray[np.float64]:
         """Return the diagonal of the Hamiltonian in the charge basis."""

--- a/scqubits/settings.py
+++ b/scqubits/settings.py
@@ -172,3 +172,23 @@ OVERLAP_THRESHOLD = 0.5
 # The following determines the threshold for the number of nodes above which the
 # symbolic inversion of the capacitance matrix is skipped.
 SYM_INVERSION_MAX_NODES = 3
+
+# Convergence-diagnostics settings (see scqubits.core.convergence) ----------------------
+# Default mode for estimate_convergence() when not explicitly specified.
+CONVERGENCE_DEFAULT_MODE = "verify"
+# Default floor on the local isolation gap (in GHz) used when normalising
+# convergence estimates by an observed spectral gap.
+CONVERGENCE_G_FLOOR_GHZ = 1e-3
+# Default dimensionless threshold for observed-gap-scale convergence verdicts.
+CONVERGENCE_DEFAULT_GAP_REL = 1e-3
+# Cluster-detection threshold: a consecutive run of eigenvalues forms a cluster
+# when its internal max-gap is below this ratio times the external gap.
+CONVERGENCE_CLUSTER_RATIO = 0.1
+# Safety factor S applied to one-step refinement estimates,
+# abs_err_est = S * |E(N+dN) - E(N)|. Default 2.0 corresponds to assuming a
+# refinement-ratio bound R <= 1/2 (calibration tightens or loosens as needed).
+CONVERGENCE_SAFETY_FACTOR = 2.0
+# Floor on rates (Hz) when comparing coherence channels; below this, the
+# rate-relative-error denominator is clamped to avoid divide-by-zero in
+# T = 1/Gamma reporting. (Used in PR-3.)
+CONVERGENCE_RATE_FLOOR_HZ = 1.0

--- a/scqubits/tests/test_convergence.py
+++ b/scqubits/tests/test_convergence.py
@@ -1,0 +1,270 @@
+# test_convergence.py
+#
+# This file is part of scqubits.
+#
+#    Copyright (c) 2019 and later, Jens Koch and Peter Groszkowski
+#    All rights reserved.
+#
+#    This source code is licensed under the BSD-style license found in the
+#    LICENSE file in the root directory of this source tree.
+############################################################################
+"""Integration tests for the convergence-diagnostics framework.
+
+PR-1 scope: dataclass construction; verify / strict / quick mode energy
+convergence on Transmon; quick-mode degradation; recommendations; the
+top-level ``estimate_convergence`` shim.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import scqubits as sq
+
+from scqubits.core.convergence_report import (
+    EVIDENCE_ORDER,
+    ConvergenceReport,
+    ImplementationAudit,
+    LevelVerdict,
+    evidence_at_least,
+)
+
+pytestmark = pytest.mark.slow
+
+
+# ----------------------------------------------------------------- dataclass tests
+
+
+class TestDataclasses:
+    def _make_audit(self) -> ImplementationAudit:
+        return ImplementationAudit(
+            scqubits_version="x.y.z",
+            scqubits_commit=None,
+            qubit_class="Transmon",
+            basis="charge",
+            diagonalization_method="default",
+            cutoff_parameters={"ncut": 31},
+            fd_stencil_order=None,
+            fd_box=None,
+            nonpoly_backend=None,
+            n_levels_requested=5,
+            n_levels_buffer=0,
+            mode="verify",
+            refinement="one_step",
+        )
+
+    def test_level_verdict_is_frozen(self):
+        verdict = LevelVerdict(
+            level_index=0,
+            status="converged",
+            status_scope="absolute",
+            evidence="verified_empirical",
+            abs_err_est_GHz=1e-10,
+            eps_gap_est=None,
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            verdict.level_index = 1  # type: ignore[misc]
+
+    def test_implementation_audit_is_frozen(self):
+        audit = self._make_audit()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            audit.qubit_class = "Foo"  # type: ignore[misc]
+
+    def test_convergence_report_asdict_roundtrip(self):
+        verdict = LevelVerdict(
+            level_index=0,
+            status="converged",
+            status_scope="absolute",
+            evidence="verified_empirical",
+            abs_err_est_GHz=1e-10,
+            eps_gap_est=None,
+        )
+        report = ConvergenceReport(
+            per_level=[verdict],
+            aggregate_status="converged",
+            worst_level=0,
+            channel_breakdown_GHz={"charge": 1e-10},
+            clusters=[(0,)],
+            recommendations=[],
+            implementation_audit=self._make_audit(),
+        )
+        d = dataclasses.asdict(report)
+        assert d["aggregate_status"] == "converged"
+        assert d["per_level"][0]["level_index"] == 0
+        assert d["implementation_audit"]["mode"] == "verify"
+
+    def test_evidence_ordering(self):
+        # certified is the strongest; unverified the weakest.
+        assert evidence_at_least("certified", "unverified")
+        assert evidence_at_least("verified_empirical", "calibrated")
+        assert not evidence_at_least("diagnostic", "calibrated")
+        # Sanity: the order tuple matches the docstring.
+        assert EVIDENCE_ORDER[0] == "certified"
+        assert EVIDENCE_ORDER[-1] == "unverified"
+
+
+# ---------------------------------------------------------------- API validation
+
+
+class TestAPIValidation:
+    def test_estimate_convergence_on_non_checkable_raises(self):
+        # Oscillator is not (yet) ConvergenceCheckable.
+        osc = sq.Oscillator(E_osc=5.0, truncated_dim=3)
+        with pytest.raises(TypeError, match="does not implement convergence checking"):
+            sq.estimate_convergence(osc, n_levels=2, mode="verify")
+
+    def test_invalid_mode_raises(self):
+        tmon = sq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        with pytest.raises(ValueError, match="mode must be"):
+            tmon.estimate_convergence(n_levels=3, mode="turbo")  # type: ignore[arg-type]
+
+    def test_invalid_scope_raises(self):
+        tmon = sq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        with pytest.raises(ValueError, match="scope must be"):
+            tmon.estimate_convergence(
+                n_levels=3, scope="LC_scale"  # type: ignore[arg-type]
+            )
+
+    def test_include_derived_not_implemented(self):
+        # PR-1 doesn't implement derived sub-channels.
+        tmon = sq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        with pytest.raises(NotImplementedError, match="include_derived=True"):
+            tmon.estimate_convergence(n_levels=3, include_derived=True)
+
+
+# ------------------------------------------------------------- verify-mode tests
+
+
+class TestEnergyVerifyMode:
+    def test_well_converged_transmon_is_converged(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = sq.estimate_convergence(
+            tmon, n_levels=5, mode="verify", target_abs_GHz=1e-4
+        )
+        assert report.aggregate_status == "converged"
+        # All five levels should be converged.
+        statuses = {v.status for v in report.per_level}
+        assert statuses == {"converged"}
+        # Evidence should be verified_empirical (one-step refinement).
+        evidences = {v.evidence for v in report.per_level}
+        assert evidences == {"verified_empirical"}
+        # The audit records the requested mode and the cutoff parameter.
+        assert report.implementation_audit.mode == "verify"
+        assert report.implementation_audit.cutoff_parameters["ncut"] == 31
+
+    def test_undersized_transmon_is_underconverged(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=6, truncated_dim=6)
+        report = sq.estimate_convergence(
+            tmon, n_levels=5, mode="verify", target_abs_GHz=1e-6
+        )
+        assert report.aggregate_status == "underconverged"
+        # Recommendation should propose increasing ncut.
+        assert any("ncut" in r for r in report.recommendations)
+
+    def test_absolute_scope_without_target_returns_unverified(self):
+        # The report still contains abs_err_est_GHz per level, but status
+        # defaults to unverified when no target is supplied.
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = sq.estimate_convergence(tmon, n_levels=3, mode="verify")
+        for v in report.per_level:
+            assert v.status == "unverified"
+            assert v.abs_err_est_GHz is not None
+        assert any("target_abs_GHz" in r for r in report.recommendations)
+
+    def test_observed_gap_scope_uses_local_isolation(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = sq.estimate_convergence(
+            tmon, n_levels=4, mode="verify", scope="observed_gap_scale"
+        )
+        # eps_gap_est is populated for every level (buffer ensures
+        # upper-gap is available for the topmost requested level).
+        for v in report.per_level:
+            assert v.eps_gap_est is not None
+            assert v.eps_gap_est >= 0.0
+        # The audit records the buffer.
+        assert report.implementation_audit.n_levels_buffer == 1
+
+    def test_per_level_count_matches_request(self):
+        tmon = sq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = sq.estimate_convergence(
+            tmon, n_levels=4, mode="verify", target_abs_GHz=1e-4
+        )
+        assert len(report.per_level) == 4
+
+
+# ------------------------------------------------------------- strict-mode tests
+
+
+class TestEnergyStrictMode:
+    def test_strict_mode_ratio_test_for_underconverged_input(self):
+        # At small ncut the spectrum is far from converged; strict mode
+        # should still produce a coherent report (the ratio test may or
+        # may not detect asymptoticity at this small a problem).
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=8, truncated_dim=4)
+        report = sq.estimate_convergence(
+            tmon, n_levels=3, mode="strict", target_abs_GHz=1e-6
+        )
+        assert report.implementation_audit.mode == "strict"
+        assert report.implementation_audit.refinement == "ratio_test"
+        # The estimator method records whether the ratio test succeeded.
+        methods = {v.estimator_method for v in report.per_level}
+        assert methods.issubset(
+            {"ratio_test", "ratio_test_failed_fallback_one_step", "one_step"}
+        )
+
+
+# --------------------------------------------------------------- quick-mode tests
+
+
+class TestEnergyQuickMode:
+    def test_quick_mode_never_says_converged(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = sq.estimate_convergence(tmon, n_levels=5, mode="quick")
+        # Best possible quick-mode status is likely_converged.
+        for v in report.per_level:
+            assert v.status in {
+                "likely_converged",
+                "marginal",
+                "underconverged",
+                "unverified",
+            }
+            assert v.status != "converged"
+
+    def test_quick_mode_well_converged_is_likely_converged(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = sq.estimate_convergence(tmon, n_levels=4, mode="quick")
+        assert report.aggregate_status == "likely_converged"
+        # No abs_err_est is provided in quick mode.
+        for v in report.per_level:
+            assert v.abs_err_est_GHz is None
+
+    def test_quick_mode_undersized_is_unverified(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=4, truncated_dim=4)
+        report = sq.estimate_convergence(tmon, n_levels=3, mode="quick")
+        assert report.aggregate_status == "unverified"
+        # Each underconverged level carries the relevant warning.
+        for v in report.per_level:
+            assert "boundary_amplitude_above_threshold" in v.warnings
+
+    def test_quick_mode_has_no_extra_diagonalization(self):
+        # The audit field n_levels_buffer is 0 for quick mode at
+        # absolute scope (no buffer needed).
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = sq.estimate_convergence(tmon, n_levels=3, mode="quick")
+        assert report.implementation_audit.mode == "quick"
+        assert report.implementation_audit.n_levels_buffer == 0
+
+
+# ---------------------------------------------------------------- cluster tests
+
+
+class TestClusterIntegration:
+    def test_clusters_field_partitions_levels(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = sq.estimate_convergence(
+            tmon, n_levels=4, mode="verify", target_abs_GHz=1e-4
+        )
+        flattened = [k for c in report.clusters for k in c]
+        assert sorted(flattened) == list(range(4))

--- a/scqubits/tests/test_convergence.py
+++ b/scqubits/tests/test_convergence.py
@@ -65,12 +65,12 @@ class TestDataclasses:
             eps_gap_est=None,
         )
         with pytest.raises(dataclasses.FrozenInstanceError):
-            verdict.level_index = 1  # type: ignore[misc]
+            verdict.level_index = 1
 
     def test_implementation_audit_is_frozen(self):
         audit = self._make_audit()
         with pytest.raises(dataclasses.FrozenInstanceError):
-            audit.qubit_class = "Foo"  # type: ignore[misc]
+            audit.qubit_class = "Foo"
 
     def test_convergence_report_asdict_roundtrip(self):
         verdict = LevelVerdict(
@@ -118,14 +118,12 @@ class TestAPIValidation:
     def test_invalid_mode_raises(self):
         tmon = sq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
         with pytest.raises(ValueError, match="mode must be"):
-            tmon.estimate_convergence(n_levels=3, mode="turbo")  # type: ignore[arg-type]
+            tmon.estimate_convergence(n_levels=3, mode="turbo")
 
     def test_invalid_scope_raises(self):
         tmon = sq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
         with pytest.raises(ValueError, match="scope must be"):
-            tmon.estimate_convergence(
-                n_levels=3, scope="LC_scale"  # type: ignore[arg-type]
-            )
+            tmon.estimate_convergence(n_levels=3, scope="LC_scale")
 
     def test_include_derived_not_implemented(self):
         # PR-1 doesn't implement derived sub-channels.

--- a/scqubits/tests/test_convergence_utils.py
+++ b/scqubits/tests/test_convergence_utils.py
@@ -18,6 +18,7 @@ import pytest
 from scqubits.utils.convergence_utils import (
     cluster_safe_match_energies,
     detect_clusters,
+    geometric_ratio_test,
 )
 
 # Mark all tests in this module as slow so they participate in the
@@ -122,3 +123,35 @@ class TestClusterSafeMatchEnergies:
         # Within the cluster, only the third member moved (by 0.003).
         np.testing.assert_allclose(max_diffs[1], 0.003, rtol=1e-12)
         assert max_diffs[2] == 0.0
+
+
+# ----------------------------------------------------------- geometric_ratio_test
+
+
+class TestGeometricRatioTest:
+    def test_asymptotic_cluster_extrapolates_geometric_tail(self):
+        # Movement halves each step (R = 0.5): geometric tail = d0 / (1 - R) = 2.
+        diff_first = np.asarray([1.0], dtype=np.float64)
+        diff_second = np.asarray([0.5], dtype=np.float64)
+        ratios, tail, is_asymptotic = geometric_ratio_test(diff_first, diff_second)
+        np.testing.assert_allclose(ratios, [0.5])
+        np.testing.assert_allclose(tail, [2.0])
+        assert bool(is_asymptotic[0]) is True
+
+    def test_non_asymptotic_cluster_flags_inf_tail(self):
+        # Movement grows (R = 2): not asymptotic, tail undefined (inf).
+        diff_first = np.asarray([1.0], dtype=np.float64)
+        diff_second = np.asarray([2.0], dtype=np.float64)
+        ratios, tail, is_asymptotic = geometric_ratio_test(diff_first, diff_second)
+        np.testing.assert_allclose(ratios, [2.0])
+        assert np.isinf(tail[0])
+        assert bool(is_asymptotic[0]) is False
+
+    def test_zero_first_movement_gives_inf_ratio(self):
+        # d0 already at the floor: ratio undefined (inf), so not asymptotic.
+        diff_first = np.asarray([0.0], dtype=np.float64)
+        diff_second = np.asarray([1.0], dtype=np.float64)
+        ratios, tail, is_asymptotic = geometric_ratio_test(diff_first, diff_second)
+        assert np.isinf(ratios[0])
+        assert np.isinf(tail[0])
+        assert bool(is_asymptotic[0]) is False

--- a/scqubits/tests/test_convergence_utils.py
+++ b/scqubits/tests/test_convergence_utils.py
@@ -1,0 +1,124 @@
+# test_convergence_utils.py
+#
+# This file is part of scqubits.
+#
+#    Copyright (c) 2019 and later, Jens Koch and Peter Groszkowski
+#    All rights reserved.
+#
+#    This source code is licensed under the BSD-style license found in the
+#    LICENSE file in the root directory of this source tree.
+############################################################################
+"""Unit tests for the pure-numerics helpers in ``scqubits.utils.convergence_utils``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from scqubits.utils.convergence_utils import (
+    cluster_safe_match_energies,
+    detect_clusters,
+)
+
+# Mark all tests in this module as slow so they participate in the
+# `-m "not slow"` quick suite opt-out.
+pytestmark = pytest.mark.slow
+
+
+# --------------------------------------------------------------- detect_clusters
+
+
+class TestDetectClusters:
+    def test_empty_array_returns_empty_list(self):
+        assert detect_clusters(np.asarray([], dtype=np.float64)) == []
+
+    def test_single_level_returns_singleton(self):
+        assert detect_clusters(np.asarray([1.5], dtype=np.float64)) == [(0,)]
+
+    def test_well_separated_levels_are_all_singletons(self):
+        # Gaps grow rapidly; no cluster should form.
+        evals = np.asarray([0.0, 1.0, 3.0, 7.0, 15.0], dtype=np.float64)
+        clusters = detect_clusters(evals, gap_ratio_threshold=0.1)
+        assert clusters == [(0,), (1,), (2,), (3,), (4,)]
+
+    def test_doublet_merged_when_internal_gap_below_threshold(self):
+        # Levels 1 and 2 are tightly spaced relative to the external gap
+        # of order 1.0 above and 0.97 below.
+        evals = np.asarray([0.0, 1.0, 1.001, 2.0, 3.0], dtype=np.float64)
+        clusters = detect_clusters(evals, gap_ratio_threshold=0.1)
+        # (1, 2) should be one cluster; others singletons.
+        assert (1, 2) in clusters
+        # Every index is covered exactly once.
+        flattened = [k for c in clusters for k in c]
+        assert sorted(flattened) == list(range(len(evals)))
+
+    def test_partition_invariant_random(self):
+        # Property test: for any sorted evals, partition is exhaustive
+        # and disjoint.
+        rng = np.random.default_rng(seed=42)
+        for trial in range(20):
+            n = int(rng.integers(2, 30))
+            evals = np.sort(rng.uniform(-5.0, 5.0, size=n))
+            clusters = detect_clusters(
+                evals, gap_ratio_threshold=float(rng.uniform(0.01, 0.5))
+            )
+            flat = [k for c in clusters for k in c]
+            assert sorted(flat) == list(
+                range(n)
+            ), f"Trial {trial}: partition not exhaustive or has duplicates"
+
+    def test_threshold_zero_yields_only_singletons(self):
+        # With threshold 0, no internal gap can be strictly smaller than
+        # 0 times anything finite, so all levels are singletons.
+        evals = np.asarray([0.0, 1e-12, 2e-12, 1.0], dtype=np.float64)
+        clusters = detect_clusters(evals, gap_ratio_threshold=0.0)
+        assert clusters == [(0,), (1,), (2,), (3,)]
+
+
+# ------------------------------------------------------ cluster_safe_match_energies
+
+
+class TestClusterSafeMatchEnergies:
+    def test_identical_spectra_zero_max_diff(self):
+        evals = np.asarray([0.0, 1.0, 2.0, 3.0], dtype=np.float64)
+        clusters = [(0,), (1,), (2,), (3,)]
+        out_clusters, max_diffs = cluster_safe_match_energies(evals, evals, clusters)
+        assert out_clusters == clusters
+        np.testing.assert_array_equal(max_diffs, np.zeros(4))
+
+    def test_singleton_diff_returns_absolute_value(self):
+        evals_a = np.asarray([0.0, 1.0, 2.0], dtype=np.float64)
+        evals_b = np.asarray([0.01, 1.0, 1.97], dtype=np.float64)
+        clusters = [(0,), (1,), (2,)]
+        _, max_diffs = cluster_safe_match_energies(evals_a, evals_b, clusters)
+        np.testing.assert_allclose(max_diffs, [0.01, 0.0, 0.03])
+
+    def test_cluster_sort_then_compare_handles_intracluster_swap(self):
+        # Two near-degenerate levels swap order between the two spectra;
+        # cluster-aware sort-then-compare should report ~zero diff.
+        evals_a = np.asarray([0.0, 1.0, 1.001, 5.0], dtype=np.float64)
+        # If b's two near-degenerate levels are swapped in label but the
+        # cluster sort-then-compare treats them as a set, the diff is 0.
+        evals_b_sorted = np.asarray([0.0, 1.0, 1.001, 5.0], dtype=np.float64)
+        clusters = [(0,), (1, 2), (3,)]
+        _, max_diffs = cluster_safe_match_energies(evals_a, evals_b_sorted, clusters)
+        np.testing.assert_allclose(max_diffs, [0.0, 0.0, 0.0])
+
+    def test_mismatched_lengths_raises(self):
+        with pytest.raises(ValueError, match="different lengths"):
+            cluster_safe_match_energies(
+                np.asarray([0.0, 1.0]),
+                np.asarray([0.0, 1.0, 2.0]),
+                [(0,), (1,)],
+            )
+
+    def test_max_picks_largest_within_cluster(self):
+        # Cluster of three levels with small but distinct shifts.
+        evals_a = np.asarray([0.0, 1.0, 1.001, 1.002, 5.0], dtype=np.float64)
+        evals_b = np.asarray([0.0, 1.0, 1.001, 1.005, 5.0], dtype=np.float64)
+        clusters = [(0,), (1, 2, 3), (4,)]
+        _, max_diffs = cluster_safe_match_energies(evals_a, evals_b, clusters)
+        assert max_diffs[0] == 0.0
+        # Within the cluster, only the third member moved (by 0.003).
+        np.testing.assert_allclose(max_diffs[1], 0.003, rtol=1e-12)
+        assert max_diffs[2] == 0.0

--- a/scqubits/utils/convergence_utils.py
+++ b/scqubits/utils/convergence_utils.py
@@ -15,8 +15,9 @@ This module contains backend-agnostic functions used by
 :mod:`scqubits.core.convergence`. Keeping them separate makes them
 unit-testable without instantiating a qubit.
 
-PR-1 scope: cluster detection and cluster-safe energy matching.
-PR-2 will add: subspace-angle, wavefunction-overlap, ratio-test arithmetic.
+PR-1 scope: cluster detection, cluster-safe energy matching, and the
+geometric ratio test.
+PR-2 will add: subspace-angle, wavefunction-overlap.
 PR-3 will add: rate-relative-error.
 """
 
@@ -168,3 +169,52 @@ def cluster_safe_match_energies(
     # PR-2 may add a centroid-overlap-based matching for cases where the
     # cluster structure itself changes between cutoffs.
     return list(clusters_a), max_diffs
+
+
+def geometric_ratio_test(
+    diff_first: npt.NDArray[np.float64],
+    diff_second: npt.NDArray[np.float64],
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.bool_]]:
+    """Run a per-cluster geometric ratio test on successive refinement movements.
+
+    Given the absolute spectral movements between consecutive cutoffs --
+    ``diff_first`` for the base-to-first-refinement step and ``diff_second`` for
+    the first-to-second-refinement step -- this characterizes whether each
+    cluster is in the geometric (asymptotically converging) regime and, if so,
+    extrapolates the remaining tail error from a geometric series.
+
+    Parameters
+    ----------
+    diff_first:
+        Per-cluster absolute eigenvalue movement of the first refinement step.
+        Entries are non-negative.
+    diff_second:
+        Per-cluster absolute eigenvalue movement of the second refinement step,
+        aligned element-wise with ``diff_first``.
+
+    Returns
+    -------
+    ratios
+        ``diff_second / diff_first`` per cluster, with ``inf`` wherever
+        ``diff_first`` is zero (the movement is already at the floor and the
+        ratio is undefined).
+    geometric_tail
+        The geometric-series tail estimate ``diff_first / (1 - ratios)`` for
+        clusters with ``ratios < 1``, and ``inf`` elsewhere.
+    is_asymptotic
+        ``True`` for clusters with ``ratios < 1``, i.e. those whose movement is
+        shrinking and for which the geometric extrapolation is meaningful.
+    """
+    ratios = np.divide(
+        diff_second,
+        diff_first,
+        out=np.full_like(diff_first, np.inf),
+        where=diff_first > 0,
+    )
+    geometric_tail = np.where(
+        ratios < 1.0,
+        diff_first / np.clip(1.0 - ratios, 1e-30, None),
+        np.inf,
+    )
+    is_asymptotic = ratios < 1.0
+    return ratios, geometric_tail, is_asymptotic

--- a/scqubits/utils/convergence_utils.py
+++ b/scqubits/utils/convergence_utils.py
@@ -22,7 +22,6 @@ PR-3 will add: rate-relative-error.
 
 from __future__ import annotations
 
-from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -80,12 +79,12 @@ def detect_clusters(
             # External-gap candidates: below the cluster's first level
             # and above the cluster-extension candidate. Only finite
             # sides are usable as external references.
-            ext_below: Optional[float] = (
+            ext_below: float | None = (
                 float(evals[cluster[0]] - evals[cluster[0] - 1])
                 if cluster[0] > 0
                 else None
             )
-            ext_above: Optional[float] = (
+            ext_above: float | None = (
                 float(evals[j + 1] - evals[j]) if j + 1 < n else None
             )
 

--- a/scqubits/utils/convergence_utils.py
+++ b/scqubits/utils/convergence_utils.py
@@ -1,0 +1,171 @@
+# convergence_utils.py
+#
+# This file is part of scqubits: a Python package for superconducting qubits,
+# Quantum 5, 583 (2021). https://quantum-journal.org/papers/q-2021-11-17-583/
+#
+#    Copyright (c) 2019 and later, Jens Koch and Peter Groszkowski
+#    All rights reserved.
+#
+#    This source code is licensed under the BSD-style license found in the
+#    LICENSE file in the root directory of this source tree.
+############################################################################
+"""Pure-numerics helpers for the convergence-diagnostics framework.
+
+This module contains backend-agnostic functions used by
+:mod:`scqubits.core.convergence`. Keeping them separate makes them
+unit-testable without instantiating a qubit.
+
+PR-1 scope: cluster detection and cluster-safe energy matching.
+PR-2 will add: subspace-angle, wavefunction-overlap, ratio-test arithmetic.
+PR-3 will add: rate-relative-error.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import numpy.typing as npt
+
+
+def detect_clusters(
+    evals: npt.NDArray[np.float64], gap_ratio_threshold: float = 0.1
+) -> list[tuple[int, ...]]:
+    """Group consecutive eigenvalues into near-degenerate clusters.
+
+    A consecutive run of levels forms a cluster when the maximum internal
+    gap is below ``gap_ratio_threshold`` times the external gap (to the
+    nearest non-cluster level). Singleton clusters are also returned (so
+    every level index appears in exactly one tuple).
+
+    Parameters
+    ----------
+    evals:
+        One-dimensional array of eigenvalues, assumed sorted ascending.
+    gap_ratio_threshold:
+        Maximum allowed internal-to-external gap ratio. Smaller values
+        merge fewer levels into clusters.
+
+    Returns
+    -------
+    A partition of ``range(len(evals))`` into tuples of consecutive
+    indices. The union of the tuples is ``set(range(len(evals)))`` and
+    they are pairwise disjoint.
+
+    Notes
+    -----
+    The algorithm is greedy and left-to-right: a singleton starts each
+    cluster; extending the cluster requires the next inter-level gap to
+    be below ``gap_ratio_threshold * external_gap``, where the external
+    gap is the larger of (a) the gap from the current cluster's lowest
+    level to its predecessor, and (b) the gap from the candidate's
+    successor (the level after the candidate). For terminal levels
+    (first / last), the missing side is treated as infinite.
+    """
+    n = len(evals)
+    if n == 0:
+        return []
+    if n == 1:
+        return [(0,)]
+
+    clusters: list[tuple[int, ...]] = []
+    i = 0
+    while i < n:
+        cluster = [i]
+        # Try to extend the cluster.
+        while cluster[-1] + 1 < n:
+            j = cluster[-1] + 1
+            internal_gap = float(evals[j] - evals[j - 1])
+
+            # External-gap candidates: below the cluster's first level
+            # and above the cluster-extension candidate. Only finite
+            # sides are usable as external references.
+            ext_below: Optional[float] = (
+                float(evals[cluster[0]] - evals[cluster[0] - 1])
+                if cluster[0] > 0
+                else None
+            )
+            ext_above: Optional[float] = (
+                float(evals[j + 1] - evals[j]) if j + 1 < n else None
+            )
+
+            # External reference = the closest (smallest) non-cluster
+            # gap on either side; this is the strictest comparison
+            # against which the internal gap must be small to count as
+            # a cluster. If neither side is available (terminal
+            # singleton), don't extend.
+            if ext_below is None and ext_above is None:
+                break
+            if ext_below is None:
+                external_gap: float = ext_above  # type: ignore[assignment]
+            elif ext_above is None:
+                external_gap = ext_below
+            else:
+                external_gap = min(ext_below, ext_above)
+
+            if internal_gap < gap_ratio_threshold * external_gap:
+                cluster.append(j)
+            else:
+                break
+
+        clusters.append(tuple(cluster))
+        i = cluster[-1] + 1
+
+    return clusters
+
+
+def cluster_safe_match_energies(
+    evals_a: npt.NDArray[np.float64],
+    evals_b: npt.NDArray[np.float64],
+    clusters_a: list[tuple[int, ...]],
+) -> tuple[list[tuple[int, ...]], npt.NDArray[np.float64]]:
+    """Map clusters from one spectrum to the same index ranges in another,
+    and return per-cluster absolute energy differences.
+
+    The two spectra are expected to correspond to the same physical
+    system at two slightly different cutoffs, both sorted ascending and
+    of the same length. Index identification is direct (cluster ``c`` in
+    spectrum A corresponds to the same index tuple in spectrum B), which
+    is appropriate when the cluster structure is stable across cutoffs.
+    Within each cluster, the comparison is on sorted eigenvalue sets, so
+    intra-cluster index swaps (eigenvalue rotations within a near-
+    degenerate block) do not produce spurious differences.
+
+    Parameters
+    ----------
+    evals_a, evals_b:
+        Eigenvalue arrays of the same length, sorted ascending.
+    clusters_a:
+        Cluster partition for ``evals_a`` (as returned by
+        :func:`detect_clusters`).
+
+    Returns
+    -------
+    A pair ``(clusters_b, max_diff_per_cluster)`` where:
+
+    - ``clusters_b`` is the index partition for ``evals_b``; in this PR
+      it is identical to ``clusters_a`` (direct-index mapping).
+    - ``max_diff_per_cluster[k]`` is the maximum of
+      ``|sorted(evals_a[c]) - sorted(evals_b[c])|`` over the indices in
+      cluster ``k``.
+
+    Raises
+    ------
+    ValueError
+        If the two spectra have different lengths.
+    """
+    if len(evals_a) != len(evals_b):
+        raise ValueError(
+            f"Spectra have different lengths: {len(evals_a)} vs {len(evals_b)}"
+        )
+
+    max_diffs = np.empty(len(clusters_a), dtype=np.float64)
+    for idx, cluster in enumerate(clusters_a):
+        sorted_a = np.sort(evals_a[list(cluster)])
+        sorted_b = np.sort(evals_b[list(cluster)])
+        max_diffs[idx] = float(np.max(np.abs(sorted_a - sorted_b)))
+
+    # PR-1 uses direct-index mapping for cluster correspondence.
+    # PR-2 may add a centroid-overlap-based matching for cases where the
+    # cluster structure itself changes between cutoffs.
+    return list(clusters_a), max_diffs

--- a/scqubits/utils/convergence_utils.py
+++ b/scqubits/utils/convergence_utils.py
@@ -141,13 +141,13 @@ def cluster_safe_match_energies(
 
     Returns
     -------
-    A pair ``(clusters_b, max_diff_per_cluster)`` where:
-
-    - ``clusters_b`` is the index partition for ``evals_b``; in this PR
-      it is identical to ``clusters_a`` (direct-index mapping).
-    - ``max_diff_per_cluster[k]`` is the maximum of
-      ``|sorted(evals_a[c]) - sorted(evals_b[c])|`` over the indices in
-      cluster ``k``.
+    clusters_b : list of tuple of int
+        The index partition for ``evals_b``; in this PR identical to
+        ``clusters_a`` (direct-index mapping).
+    max_diff_per_cluster : ndarray
+        Entry ``k`` is the maximum of
+        ``|sorted(evals_a[c]) - sorted(evals_b[c])|`` over the indices in
+        cluster ``k``.
 
     Raises
     ------


### PR DESCRIPTION
## Summary

First stage of a convergence-detection framework for scqubits. It answers a
practical question for any truncated qubit: *for the cutoff I chose, how accurate
is the result, and what should I change if it is not accurate enough?* The
recommended answer is **verified refinement** — clone the qubit, bump a cutoff,
re-diagonalize, and compare — with an explicit *evidence* label on every
numerical conclusion so a cheap heuristic is never silently promoted to a strong
claim.

This is **PR-1 of 3** and covers the **energy** sub-channel for `Transmon`.

### What's added
- `core/convergence_report.py` — frozen dataclasses + `Literal` schema
  (`LevelVerdict`, `ConvergenceReport`, `ImplementationAudit`) that separate the
  *estimated* error from the *true* error.
- `core/convergence.py` — `ConvergenceCheckable` mixin (parallel to
  `NoisySystem`) and the refinement engine; `quick` / `verify` / `strict` modes.
- `utils/convergence_utils.py` — cluster detection and cluster-safe eigenvalue
  matching (near-degenerate levels are compared as a set, so an ordering swap
  between cutoffs does not produce a spurious failure).
- `core/transmon.py` — opts in via the mixin, declares
  `_convergence_axes = ("ncut",)`, adds the boundary-amplitude diagnostic used by
  quick mode.
- `settings.py` — `CONVERGENCE_*` defaults; `__init__.py` — public exports;
  `pyproject.toml` — `slow` pytest marker.
- `tests/test_convergence.py`, `tests/test_convergence_utils.py`.

### Modes
- `quick` — cheap boundary-amplitude diagnostic, no extra diagonalization; never
  claims `converged` (best case `likely_converged`).
- `verify` (default) — one refinement diagonalization; evidence
  `verified_empirical`.
- `strict` — two refinements + ratio/asymptoticity test; evidence `calibrated`
  when the asymptotic regime is confirmed, else falls back with a warning.

The dataclasses and API are forward-compatible with the remaining hard-coded
qubits, custom `Circuit`, and `HilbertSpace` composition without schema changes.

## Test plan
- [ ] `pytest scqubits/tests/test_convergence.py scqubits/tests/test_convergence_utils.py`
- [ ] `pytest --pyargs scqubits -m "not slow"` — existing suite unaffected
- [ ] `mypy` and `black --check` clean on the new modules
- [ ] Companion user guide builds (scqubits-doc PR, linked below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)