### PR TITLE
Fix duplicate reST target breaking spec_lookup docs build

### DIFF
--- a/scqubits/core/spec_lookup.py
+++ b/scqubits/core/spec_lookup.py
@@ -135,7 +135,8 @@ class SpectrumLookupMixin(MixinCompatible):
         - Dressed Energy (``ordering="DE"``): traverse the eigenstates
           in the order of their dressed energy, and find the corresponding bare
           state label by overlaps (default).
-        - Lexical (``ordering="LX"``): traverse the bare states in `lexical order`_,
+        - Lexical (``ordering="LX"``): traverse the bare states in
+          `lexical order <https://en.wikipedia.org/wiki/Lexicographic_order#Cartesian_products>`__,
           and perform the branch analysis generalized from Dumas et al. (2024).
         - Bare Energy (``ordering="BE"``): traverse the bare states in order
           of their energy before coupling and perform label assignment.
@@ -166,8 +167,6 @@ class SpectrumLookupMixin(MixinCompatible):
         indices organized by the bare indices. E.g. if the dimensions of the
         subsystems are D0, D1 and D2, the returned array will be ravelled from
         the shape ``(D0, D1, D2)``.
-
-        .. _lexical order: https://en.wikipedia.org/wiki/Lexicographic_order#Cartesian_products/
         """
         if ordering == "LX" or ordering == "BE":
             return self._branch_analysis(
@@ -1056,7 +1055,8 @@ class SpectrumLookupMixin(MixinCompatible):
         Two ordering methods for the labeling are provided:
 
         - Lexical (``ordering="LX"``): traverse the bare states in
-          `lexical order`_ and perform the branch analysis generalized from
+          `lexical order <https://en.wikipedia.org/wiki/Lexicographic_order#Cartesian_products>`__
+          and perform the branch analysis generalized from
           Dumas et al. (2024).
         - Bare Energy (``ordering="BE"``): traverse the bare states in order
           of their energy before coupling and perform label assignment.
@@ -1091,8 +1091,6 @@ class SpectrumLookupMixin(MixinCompatible):
         indices organized by the bare indices. E.g. if the dimensions of the
         subsystems are D0, D1 and D2, the returned array will be ravelled from
         the shape ``(D0, D1, D2)``.
-
-        .. _lexical order: https://en.wikipedia.org/wiki/Lexicographic_order#Cartesian_products/
         """
         dressed_indices = np.empty(shape=self._parameters.counts, dtype=object)
 


### PR DESCRIPTION
## Summary

`SpectrumLookupMixin.generate_lookup` and `_branch_analysis` each defined the
same explicit reST target ``.. _lexical order:`` and referenced it via the named
form `` `lexical order`_ ``. Each docstring is fine on its own, but Sphinx
renders both into the same page (the class page, and the inherited
`ParameterSweep` pages). docutils then sees a duplicate explicit target name,
discards it, and the references fail with:

```
ERROR: Unknown target name: "lexical order".
```

(×3 across the docs build).

This replaces both with inline **anonymous** links
(`` `lexical order <url>`__ ``), which create no named target and therefore
cannot collide — and render correctly whether a docstring appears alone or
alongside the other. Also drops a stray trailing ``/`` on the URL fragment.

Docstring-only; no API or behavior change.

## Test plan
- [ ] `make clean && make html` in scqubits-doc no longer emits the
      `Unknown target name: "lexical order"` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)