### PR TITLE
Add convergence wavefunction + matrix-element channels (Transmon)

### DIFF
--- a/scqubits/core/convergence.py
+++ b/scqubits/core/convergence.py
@@ -25,6 +25,7 @@ diagnostics never claim ``converged`` (per the published design specification).
 from __future__ import annotations
 
 import copy
+import dataclasses
 
 from typing import Any, Sequence
 
@@ -136,11 +137,14 @@ class ConvergenceCheckable:
             Floor on the local isolation gap (default ``1e-3`` GHz = 1 MHz)
             to avoid divide-by-tiny-numbers when the gap is very small.
         include_derived:
-            PR-1: ignored; raises ``NotImplementedError`` if set to True
-            in this PR (the wavefunctions/matrix-elements/coherence
-            channels arrive in PR-2 and PR-3).
+            If True, additionally assess the requested ``derived_quantities``
+            and attach their per-level sub-reports under
+            :attr:`ConvergenceReport.derived`. Requires ``mode`` of
+            ``"verify"`` or ``"strict"`` -- derived quantities need a
+            refinement comparison.
         derived_quantities:
-            PR-1: ignored.
+            Subset of ``{"wavefunctions", "matrix_elements"}`` to assess when
+            ``include_derived`` is set. ``"coherence"`` arrives in PR-3.
         refinement:
             ``"one_step"`` for verify mode; ``"ratio_test"`` for strict
             mode. Coerced to match ``mode`` if inconsistent.
@@ -162,12 +166,30 @@ class ConvergenceCheckable:
             raise ValueError(
                 f"refinement must be 'one_step' or 'ratio_test'; " f"got {refinement!r}"
             )
+        requested_derived: tuple[str, ...] = tuple(derived_quantities or ())
         if include_derived:
-            raise NotImplementedError(
-                "include_derived=True is not yet available in this version. "
-                "Wavefunctions and matrix elements arrive in PR-2; coherence "
-                "in PR-3."
-            )
+            if mode == "quick":
+                raise ValueError(
+                    "include_derived requires mode='verify' or 'strict'; "
+                    "derived quantities need a refinement comparison"
+                )
+            if not requested_derived:
+                raise ValueError(
+                    "include_derived=True requires derived_quantities, e.g. "
+                    "['wavefunctions', 'matrix_elements']"
+                )
+            unknown = set(requested_derived) - {
+                "wavefunctions",
+                "matrix_elements",
+                "coherence",
+            }
+            if unknown:
+                raise ValueError(
+                    f"unknown derived_quantities: {sorted(unknown)}; valid: "
+                    "'wavefunctions', 'matrix_elements'"
+                )
+            if "coherence" in requested_derived:
+                raise NotImplementedError("coherence convergence arrives in PR-3")
         if not self._convergence_axes:
             raise NotImplementedError(
                 f"{type(self).__name__} does not declare _convergence_axes; "
@@ -208,6 +230,8 @@ class ConvergenceCheckable:
             target_gap_rel=target_gap_rel,
             g_floor_GHz=g_floor_GHz,
             refinement=refinement,
+            include_derived=include_derived,
+            derived_quantities=requested_derived,
         )
 
     # ------------------------------------------------------------ engine helpers
@@ -368,8 +392,15 @@ class ConvergenceCheckable:
         target_gap_rel: float,
         g_floor_GHz: float,
         refinement: str,
+        include_derived: bool = False,
+        derived_quantities: tuple[str, ...] = (),
     ) -> ConvergenceReport:
-        """Verify / strict mode: refine cutoff(s), compare cluster-matched energies."""
+        """Verify / strict mode: refine cutoff(s), compare cluster-matched energies.
+
+        When ``include_derived`` is set, the refined eigenvectors (and clones,
+        for matrix elements) are reused to build the requested derived per-level
+        sub-reports, which are attached under ``ConvergenceReport.derived``.
+        """
         # For PR-1, we handle exactly one axis. Multi-axis aggregation
         # (refine one axis at a time, combine absolute errors by triangle
         # inequality) will be added when Circuit lands in Stage 3.
@@ -384,14 +415,16 @@ class ConvergenceCheckable:
 
         current_value = getattr(self, axis)
         clone_1 = self._convergence_clone_at({axis: current_value + step})
-        evals_n1, _ = clone_1.eigensys(evals_count=n_eigs)  # type: ignore[attr-defined]
+        evals_n1, evecs_n1 = clone_1.eigensys(evals_count=n_eigs)  # type: ignore[attr-defined]
 
         evals_n2: npt.NDArray[np.float64] | None = None
+        evecs_n2: npt.NDArray[np.float64] | None = None
+        clone_2: ConvergenceCheckable | None = None
         if refinement == "ratio_test":
             clone_2 = self._convergence_clone_at({axis: current_value + 2 * step})
-            evals_n2, _ = clone_2.eigensys(evals_count=n_eigs)  # type: ignore[attr-defined]
+            evals_n2, evecs_n2 = clone_2.eigensys(evals_count=n_eigs)  # type: ignore[attr-defined]
 
-        return self._convergence_build_energy_report(
+        report = self._convergence_build_energy_report(
             evals_n0=evals_n0[:n_levels],
             evals_n1=evals_n1[:n_levels],
             evals_n2=evals_n2[:n_levels] if evals_n2 is not None else None,
@@ -403,6 +436,28 @@ class ConvergenceCheckable:
             target_abs_GHz=target_abs_GHz,
             target_gap_rel=target_gap_rel,
             g_floor_GHz=g_floor_GHz,
+            refinement=refinement,
+            axis=axis,
+        )
+
+        if not include_derived:
+            return report
+
+        return self._attach_derived_reports(
+            report=report,
+            derived_quantities=derived_quantities,
+            evals_n0=evals_n0,
+            evecs_n0=evecs_n0,
+            evecs_n1=evecs_n1,
+            evecs_n2=evecs_n2,
+            clone_1=clone_1,
+            clone_2=clone_2,
+            ncut_0=int(current_value),
+            step=step,
+            n_levels=n_levels,
+            n_buffer=n_buffer,
+            mode=mode,
+            target_gap_rel=target_gap_rel,
             refinement=refinement,
             axis=axis,
         )
@@ -559,6 +614,101 @@ class ConvergenceCheckable:
                 "per level without thresholding"
             )
         return recommendations
+
+    def _attach_derived_reports(
+        self,
+        report: ConvergenceReport,
+        derived_quantities: tuple[str, ...],
+        evals_n0: npt.NDArray[np.float64],
+        evecs_n0: npt.NDArray[np.float64],
+        evecs_n1: npt.NDArray[np.float64],
+        evecs_n2: npt.NDArray[np.float64] | None,
+        clone_1: "ConvergenceCheckable",
+        clone_2: "ConvergenceCheckable | None",
+        ncut_0: int,
+        step: int,
+        n_levels: int,
+        n_buffer: int,
+        mode: str,
+        target_gap_rel: float,
+        refinement: str,
+        axis: str,
+    ) -> ConvergenceReport:
+        """Build and attach the requested per-level derived sub-reports.
+
+        Reuses the already-computed reference and refined eigenvectors (and the
+        refinement clones, for matrix elements) to assess wavefunction and
+        matrix-element convergence on the same per-level footing as energies,
+        then returns ``report`` with its ``derived`` mapping populated.
+        """
+        channel = self._convergence_truncation_channel(axis)
+        clusters = cutils.detect_clusters(
+            evals_n0[:n_levels],
+            gap_ratio_threshold=settings.CONVERGENCE_CLUSTER_RATIO,
+        )
+        audit = self._convergence_audit(
+            n_levels=n_levels, n_buffer=n_buffer, mode=mode, refinement=refinement
+        )
+        ncut_1 = ncut_0 + step
+        ncut_2 = ncut_0 + 2 * step
+        derived: dict[str, ConvergenceReport] = {}
+
+        if "wavefunctions" in derived_quantities:
+            movement_first = _wavefunction_movement(
+                evecs_n0, evecs_n1, ncut_0, ncut_1, clusters, n_levels
+            )
+            movement_second: npt.NDArray[np.float64] | None = None
+            if refinement == "ratio_test" and evecs_n2 is not None:
+                movement_second = _wavefunction_movement(
+                    evecs_n1, evecs_n2, ncut_1, ncut_2, clusters, n_levels
+                )
+            derived["wavefunctions"] = _build_metric_report(
+                movement_first=movement_first,
+                movement_second=movement_second,
+                channel=channel,
+                estimator_method="wavefunction_overlap",
+                clusters=clusters,
+                n_levels=n_levels,
+                mode=mode,
+                target_gap_rel=target_gap_rel,
+                refinement=refinement,
+                audit=audit,
+                axis=axis,
+                current_value=ncut_0,
+                step=step,
+            )
+
+        if "matrix_elements" in derived_quantities:
+            me_movement_first, skipped = _matrix_element_movement(
+                self, clone_1, evecs_n0, evecs_n1, n_levels
+            )
+            me_movement_second: npt.NDArray[np.float64] | None = None
+            if (
+                refinement == "ratio_test"
+                and clone_2 is not None
+                and evecs_n2 is not None
+            ):
+                me_movement_second, _ = _matrix_element_movement(
+                    clone_1, clone_2, evecs_n1, evecs_n2, n_levels
+                )
+            derived["matrix_elements"] = _build_metric_report(
+                movement_first=me_movement_first,
+                movement_second=me_movement_second,
+                channel=channel,
+                estimator_method="matrix_element_frobenius",
+                clusters=clusters,
+                n_levels=n_levels,
+                mode=mode,
+                target_gap_rel=target_gap_rel,
+                refinement=refinement,
+                audit=audit,
+                axis=axis,
+                current_value=ncut_0,
+                step=step,
+                skipped=skipped,
+            )
+
+        return dataclasses.replace(report, derived=derived)
 
 
 # ------------------------------------------------------------ module helpers
@@ -781,6 +931,183 @@ def _aggregate_worst(verdicts: list[LevelVerdict]) -> tuple[int, Status]:
             worst_rank = r
             worst_idx = k
     return worst_idx, verdicts[worst_idx].status
+
+
+# Reference-norm floor for relative matrix-element comparison, guarding against
+# division by a vanishing (selection-rule-zero) reference row/column.
+_MATELEM_REF_FLOOR = 1e-12
+
+
+def _wavefunction_movement(
+    evecs_a: npt.NDArray[np.float64],
+    evecs_b: npt.NDArray[np.float64],
+    ncut_a: int,
+    ncut_b: int,
+    clusters: list[tuple[int, ...]],
+    n_levels: int,
+) -> npt.NDArray[np.float64]:
+    """Per-level wavefunction movement between two cutoffs.
+
+    Isolated levels use the overlap deficit ``1 - |<a_k | b_k>|``; near-degenerate
+    clusters use the subspace angle (assigned to every member), which is robust to
+    eigenvector rotations within the block.
+    """
+    overlaps = cutils.wavefunction_overlap(
+        evecs_a[:, :n_levels], evecs_b[:, :n_levels], ncut_a, ncut_b
+    )
+    movement = 1.0 - np.minimum(1.0, overlaps)
+    ncut_max = max(ncut_a, ncut_b)
+    a = cutils.pad_charge_basis(evecs_a[:, :n_levels], ncut_a, ncut_max)
+    b = cutils.pad_charge_basis(evecs_b[:, :n_levels], ncut_b, ncut_max)
+    for cluster in clusters:
+        if len(cluster) > 1:
+            cols = list(cluster)
+            angle = cutils.subspace_angle(a[:, cols], b[:, cols])
+            for k in cluster:
+                movement[k] = angle
+    return movement
+
+
+def _matrix_element_movement(
+    qubit_a: Any,
+    qubit_b: Any,
+    evecs_a: npt.NDArray[np.float64],
+    evecs_b: npt.NDArray[np.float64],
+    n_levels: int,
+) -> tuple[npt.NDArray[np.float64], list[str]]:
+    """Per-level relative matrix-element movement between two cutoffs.
+
+    For each operator returned by ``get_operator_names`` the ``n_levels`` x
+    ``n_levels`` matrix-element table is formed at both cutoffs; level ``k`` is
+    assigned the worst relative change of its matrix-element row and column,
+    maximized over operators. The relative change normalizes by the refined
+    table's row/column norm, floored to guard against selection-rule zeros.
+    Operators that raise or return a shape-incompatible table are skipped and
+    reported (graceful degradation), not silently dropped.
+    """
+    movement = np.zeros(n_levels, dtype=np.float64)
+    skipped: list[str] = []
+    for op_name in qubit_a.get_operator_names():
+        try:
+            m0 = np.asarray(
+                qubit_a.matrixelement_table(op_name, evecs=evecs_a[:, :n_levels])
+            )
+            m1 = np.asarray(
+                qubit_b.matrixelement_table(op_name, evecs=evecs_b[:, :n_levels])
+            )
+        except Exception:
+            skipped.append(op_name)
+            continue
+        if m0.shape != (n_levels, n_levels) or m1.shape != (n_levels, n_levels):
+            skipped.append(op_name)
+            continue
+        delta = np.abs(m1 - m0)
+        for k in range(n_levels):
+            row_ref = max(float(np.linalg.norm(m1[k, :])), _MATELEM_REF_FLOOR)
+            col_ref = max(float(np.linalg.norm(m1[:, k])), _MATELEM_REF_FLOOR)
+            rel_k = max(
+                float(np.linalg.norm(delta[k, :])) / row_ref,
+                float(np.linalg.norm(delta[:, k])) / col_ref,
+            )
+            movement[k] = max(float(movement[k]), rel_k)
+    return movement, skipped
+
+
+def _build_metric_report(
+    movement_first: npt.NDArray[np.float64],
+    movement_second: npt.NDArray[np.float64] | None,
+    channel: TruncationChannel,
+    estimator_method: str,
+    clusters: list[tuple[int, ...]],
+    n_levels: int,
+    mode: str,
+    target_gap_rel: float,
+    refinement: str,
+    audit: ImplementationAudit,
+    axis: str,
+    current_value: int,
+    step: int,
+    skipped: list[str] | None = None,
+) -> ConvergenceReport:
+    """Assemble a per-level ConvergenceReport for a dimensionless derived metric.
+
+    ``movement_first`` holds each level's change between the base and first
+    refinement (overlap deficit, subspace angle, or relative matrix-element
+    change). In ratio-test mode ``movement_second`` (the first-to-second
+    refinement change) drives a geometric extrapolation; levels confirmed
+    asymptotic use the extrapolated tail and are tagged ``calibrated``, the rest
+    fall back to the one-step movement with a recorded warning. Verdicts apply
+    the observed-gap-scale ladder against ``target_gap_rel``.
+    """
+    geometric_tail: npt.NDArray[np.float64] | None = None
+    asymptotic: npt.NDArray[np.bool_] | None = None
+    if refinement == "ratio_test" and movement_second is not None:
+        _, geometric_tail, asymptotic = cutils.geometric_ratio_test(
+            movement_first, movement_second
+        )
+
+    per_level_eps = np.empty(n_levels, dtype=np.float64)
+    per_level_evidence: list[Evidence] = []
+    per_level_method: list[str] = []
+    per_level_warnings: list[list[str]] = [[] for _ in range(n_levels)]
+
+    for k in range(n_levels):
+        if geometric_tail is not None and asymptotic is not None and asymptotic[k]:
+            per_level_eps[k] = float(geometric_tail[k])
+            per_level_evidence.append("calibrated")
+            per_level_method.append(f"{estimator_method}_ratio_test")
+        else:
+            per_level_eps[k] = float(movement_first[k])
+            per_level_evidence.append("verified_empirical")
+            if refinement == "ratio_test":
+                per_level_method.append(f"{estimator_method}_ratio_test_fallback")
+                per_level_warnings[k].append("ratio_test_not_asymptotic")
+            else:
+                per_level_method.append(estimator_method)
+
+    verdicts = [
+        LevelVerdict(
+            level_index=k,
+            status=_assign_status(
+                abs_err_est=0.0,
+                eps_gap_est=float(per_level_eps[k]),
+                scope="observed_gap_scale",
+                target_abs_GHz=None,
+                target_gap_rel=target_gap_rel,
+            ),
+            status_scope="observed_gap_scale",
+            evidence=per_level_evidence[k],
+            abs_err_est_GHz=None,
+            eps_gap_est=float(per_level_eps[k]),
+            truncation_channel=channel,
+            estimator_method=per_level_method[k],
+            warnings=tuple(per_level_warnings[k]),
+        )
+        for k in range(n_levels)
+    ]
+    worst_idx, aggregate_status = _aggregate_worst(verdicts)
+
+    recommendations: list[str] = []
+    if any(v.status == "underconverged" for v in verdicts):
+        recommendations.append(
+            f"increase {axis} from {current_value} to at least "
+            f"{current_value + step} and re-run; a derived-quantity estimate "
+            f"exceeded the target threshold"
+        )
+    if skipped:
+        recommendations.append(
+            "skipped operators (raised or shape-incompatible): " + ", ".join(skipped)
+        )
+
+    return ConvergenceReport(
+        per_level=verdicts,
+        aggregate_status=aggregate_status,
+        worst_level=worst_idx,
+        channel_breakdown_GHz={},
+        clusters=clusters,
+        recommendations=recommendations,
+        implementation_audit=audit,
+    )
 
 
 def estimate_convergence(qubit: Any, **kwargs: Any) -> ConvergenceReport:

--- a/scqubits/core/convergence.py
+++ b/scqubits/core/convergence.py
@@ -1046,6 +1046,7 @@ def _build_metric_report(
             movement_first, movement_second
         )
 
+    safety_factor = settings.CONVERGENCE_SAFETY_FACTOR
     per_level_eps = np.empty(n_levels, dtype=np.float64)
     per_level_evidence: list[Evidence] = []
     per_level_method: list[str] = []
@@ -1053,11 +1054,15 @@ def _build_metric_report(
 
     for k in range(n_levels):
         if geometric_tail is not None and asymptotic is not None and asymptotic[k]:
+            # Geometric tail is already an extrapolated remaining-error estimate.
             per_level_eps[k] = float(geometric_tail[k])
             per_level_evidence.append("calibrated")
             per_level_method.append(f"{estimator_method}_ratio_test")
         else:
-            per_level_eps[k] = float(movement_first[k])
+            # One-step movement is a lower bound on the remaining error; apply
+            # the same safety factor the energy channel uses so a derived
+            # "converged" carries the same margin.
+            per_level_eps[k] = float(safety_factor * movement_first[k])
             per_level_evidence.append("verified_empirical")
             if refinement == "ratio_test":
                 per_level_method.append(f"{estimator_method}_ratio_test_fallback")

--- a/scqubits/tests/test_convergence.py
+++ b/scqubits/tests/test_convergence.py
@@ -125,11 +125,34 @@ class TestAPIValidation:
         with pytest.raises(ValueError, match="scope must be"):
             tmon.estimate_convergence(n_levels=3, scope="LC_scale")
 
-    def test_include_derived_not_implemented(self):
-        # PR-1 doesn't implement derived sub-channels.
+    def test_include_derived_requires_derived_quantities(self):
         tmon = sq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
-        with pytest.raises(NotImplementedError, match="include_derived=True"):
+        with pytest.raises(ValueError, match="requires derived_quantities"):
             tmon.estimate_convergence(n_levels=3, include_derived=True)
+
+    def test_include_derived_rejects_quick_mode(self):
+        tmon = sq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        with pytest.raises(ValueError, match="verify"):
+            tmon.estimate_convergence(
+                n_levels=3,
+                mode="quick",
+                include_derived=True,
+                derived_quantities=["wavefunctions"],
+            )
+
+    def test_unknown_derived_quantity_raises(self):
+        tmon = sq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        with pytest.raises(ValueError, match="unknown derived_quantities"):
+            tmon.estimate_convergence(
+                n_levels=3, include_derived=True, derived_quantities=["bogus"]
+            )
+
+    def test_coherence_derived_not_implemented(self):
+        tmon = sq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        with pytest.raises(NotImplementedError, match="coherence"):
+            tmon.estimate_convergence(
+                n_levels=3, include_derived=True, derived_quantities=["coherence"]
+            )
 
 
 # ------------------------------------------------------------- verify-mode tests
@@ -266,3 +289,90 @@ class TestClusterIntegration:
         )
         flattened = [k for c in report.clusters for k in c]
         assert sorted(flattened) == list(range(4))
+
+
+# --------------------------------------------------------- derived-channel tests
+
+
+class TestDerivedChannels:
+    def test_wavefunctions_converged_at_high_cutoff(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = tmon.estimate_convergence(
+            n_levels=4,
+            mode="verify",
+            target_abs_GHz=1e-4,
+            include_derived=True,
+            derived_quantities=["wavefunctions"],
+        )
+        wf = report.derived["wavefunctions"]
+        assert wf.aggregate_status == "converged"
+        assert len(wf.per_level) == 4
+        for v in wf.per_level:
+            assert v.eps_gap_est is not None
+            assert v.eps_gap_est < 1e-3
+            # Derived metrics are dimensionless: no GHz error estimate.
+            assert v.abs_err_est_GHz is None
+            assert v.evidence == "verified_empirical"
+            assert v.estimator_method == "wavefunction_overlap"
+
+    def test_matrix_elements_converged_at_high_cutoff(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = tmon.estimate_convergence(
+            n_levels=4,
+            mode="verify",
+            target_abs_GHz=1e-4,
+            include_derived=True,
+            derived_quantities=["matrix_elements"],
+        )
+        me = report.derived["matrix_elements"]
+        assert me.aggregate_status == "converged"
+        for v in me.per_level:
+            assert v.eps_gap_est is not None
+            assert v.estimator_method == "matrix_element_frobenius"
+
+    def test_both_channels_attached_together(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = tmon.estimate_convergence(
+            n_levels=3,
+            mode="verify",
+            target_abs_GHz=1e-4,
+            include_derived=True,
+            derived_quantities=["wavefunctions", "matrix_elements"],
+        )
+        assert set(report.derived.keys()) == {"wavefunctions", "matrix_elements"}
+
+    def test_wavefunction_movement_shrinks_with_cutoff(self):
+        # The overlap deficit at a larger base cutoff is no larger than at a
+        # clearly undersized one.
+        small = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=5, truncated_dim=4)
+        large = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=25, truncated_dim=4)
+        rep_s = small.estimate_convergence(
+            n_levels=3,
+            mode="verify",
+            include_derived=True,
+            derived_quantities=["wavefunctions"],
+        )
+        rep_l = large.estimate_convergence(
+            n_levels=3,
+            mode="verify",
+            include_derived=True,
+            derived_quantities=["wavefunctions"],
+        )
+        worst_s = max(v.eps_gap_est for v in rep_s.derived["wavefunctions"].per_level)
+        worst_l = max(v.eps_gap_est for v in rep_l.derived["wavefunctions"].per_level)
+        assert worst_l <= worst_s + 1e-12
+
+    def test_strict_mode_derived_runs_ratio_test(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = tmon.estimate_convergence(
+            n_levels=3,
+            mode="strict",
+            target_abs_GHz=1e-4,
+            include_derived=True,
+            derived_quantities=["wavefunctions"],
+        )
+        wf = report.derived["wavefunctions"]
+        # Strict mode runs the ratio test; the estimator method records either
+        # the successful ratio test or its one-step fallback.
+        for v in wf.per_level:
+            assert "ratio_test" in v.estimator_method

--- a/scqubits/tests/test_convergence_utils.py
+++ b/scqubits/tests/test_convergence_utils.py
@@ -19,6 +19,9 @@ from scqubits.utils.convergence_utils import (
     cluster_safe_match_energies,
     detect_clusters,
     geometric_ratio_test,
+    pad_charge_basis,
+    subspace_angle,
+    wavefunction_overlap,
 )
 
 # Mark all tests in this module as slow so they participate in the
@@ -155,3 +158,74 @@ class TestGeometricRatioTest:
         assert np.isinf(ratios[0])
         assert np.isinf(tail[0])
         assert bool(is_asymptotic[0]) is False
+
+
+# --------------------------------------------------------------- pad_charge_basis
+
+
+class TestPadChargeBasis:
+    def test_equal_cutoff_returns_input(self):
+        evecs = np.eye(3, dtype=np.float64)  # 2*1 + 1
+        np.testing.assert_array_equal(pad_charge_basis(evecs, 1, 1), evecs)
+
+    def test_pads_symmetrically(self):
+        # ncut 1 (dim 3) -> ncut 2 (dim 5): one zero row at each end.
+        evecs = np.asarray([[1.0], [2.0], [3.0]], dtype=np.float64)
+        out = pad_charge_basis(evecs, 1, 2)
+        assert out.shape == (5, 1)
+        np.testing.assert_array_equal(out[:, 0], [0.0, 1.0, 2.0, 3.0, 0.0])
+
+    def test_shrinking_cutoff_raises(self):
+        with pytest.raises(ValueError, match="must be >="):
+            pad_charge_basis(np.eye(5, dtype=np.float64), 2, 1)
+
+    def test_wrong_row_count_raises(self):
+        with pytest.raises(ValueError, match="expected 2"):
+            pad_charge_basis(np.eye(4, dtype=np.float64), 1, 2)
+
+
+# ----------------------------------------------------------------- subspace_angle
+
+
+class TestSubspaceAngle:
+    def test_identical_subspace_is_zero(self):
+        basis = np.linalg.qr(np.random.default_rng(0).standard_normal((6, 2)))[0]
+        assert subspace_angle(basis, basis) == pytest.approx(0.0, abs=1e-12)
+
+    def test_orthogonal_subspaces_is_one(self):
+        a = np.zeros((4, 1), dtype=np.float64)
+        a[0, 0] = 1.0
+        b = np.zeros((4, 1), dtype=np.float64)
+        b[1, 0] = 1.0
+        assert subspace_angle(a, b) == pytest.approx(1.0)
+
+    def test_forty_five_degrees_gives_sin_of_half(self):
+        a = np.zeros((3, 1), dtype=np.float64)
+        a[0, 0] = 1.0
+        b = np.asarray([[1.0], [1.0], [0.0]], dtype=np.float64) / np.sqrt(2)
+        assert subspace_angle(a, b) == pytest.approx(np.sqrt(0.5))
+
+
+# ------------------------------------------------------------ wavefunction_overlap
+
+
+class TestWavefunctionOverlap:
+    def test_identical_vectors_overlap_one(self):
+        rng = np.random.default_rng(1)
+        c = rng.standard_normal((5, 3))  # ncut 2, three levels
+        c /= np.linalg.norm(c, axis=0, keepdims=True)
+        np.testing.assert_allclose(
+            wavefunction_overlap(c, c, 2, 2), np.ones(3), atol=1e-12
+        )
+
+    def test_overlap_invariant_to_padding(self):
+        # Same physical vector, one expressed at a larger cutoff via padding.
+        c_small = np.asarray([[0.6], [0.0], [0.8]], dtype=np.float64)  # ncut 1
+        c_big = pad_charge_basis(c_small, 1, 2)  # ncut 2
+        np.testing.assert_allclose(
+            wavefunction_overlap(c_small, c_big, 1, 2), [1.0], atol=1e-12
+        )
+
+    def test_overlap_invariant_to_global_sign(self):
+        c = np.asarray([[0.6], [0.0], [0.8]], dtype=np.float64)
+        np.testing.assert_allclose(wavefunction_overlap(c, -c, 1, 1), [1.0], atol=1e-12)

--- a/scqubits/utils/convergence_utils.py
+++ b/scqubits/utils/convergence_utils.py
@@ -17,7 +17,7 @@ unit-testable without instantiating a qubit.
 
 PR-1 scope: cluster detection, cluster-safe energy matching, and the
 geometric ratio test.
-PR-2 will add: subspace-angle, wavefunction-overlap.
+PR-2 adds: charge-basis padding, subspace angle, and wavefunction overlap.
 PR-3 will add: rate-relative-error.
 """
 
@@ -218,3 +218,116 @@ def geometric_ratio_test(
     )
     is_asymptotic = ratios < 1.0
     return ratios, geometric_tail, is_asymptotic
+
+
+def pad_charge_basis(
+    evecs: npt.NDArray[np.float64],
+    ncut_old: int,
+    ncut_new: int,
+) -> npt.NDArray[np.float64]:
+    """Embed charge-basis eigenvectors into a larger-cutoff basis by zero-padding.
+
+    The transmon charge basis spans charge states ``-ncut .. +ncut`` (dimension
+    ``2 * ncut + 1``). To compare eigenvectors computed at two cutoffs they must
+    live in a common basis: the smaller-cutoff vectors are embedded into the
+    larger basis by adding ``ncut_new - ncut_old`` zero rows at each end, which
+    keeps the ``n = 0`` charge state aligned at the center.
+
+    Parameters
+    ----------
+    evecs:
+        Charge-basis eigenvectors with ``2 * ncut_old + 1`` rows; each column is
+        one eigenvector.
+    ncut_old:
+        Charge cutoff the vectors were computed at.
+    ncut_new:
+        Target charge cutoff; must be at least ``ncut_old``.
+
+    Returns
+    -------
+    The eigenvectors embedded in the ``2 * ncut_new + 1`` dimensional basis;
+    returned unchanged when the two cutoffs are equal.
+
+    Raises
+    ------
+    ValueError
+        If ``ncut_new`` is smaller than ``ncut_old`` or ``evecs`` does not have
+        ``2 * ncut_old + 1`` rows.
+    """
+    if ncut_new < ncut_old:
+        raise ValueError(f"ncut_new ({ncut_new}) must be >= ncut_old ({ncut_old})")
+    expected_rows = 2 * ncut_old + 1
+    if evecs.shape[0] != expected_rows:
+        raise ValueError(
+            f"evecs has {evecs.shape[0]} rows; expected 2*ncut_old+1 = {expected_rows}"
+        )
+    pad = ncut_new - ncut_old
+    if pad == 0:
+        return evecs
+    return np.pad(evecs, ((pad, pad), (0, 0)))
+
+
+def subspace_angle(
+    subspace_a: npt.NDArray[np.float64], subspace_b: npt.NDArray[np.float64]
+) -> float:
+    """Return the sine of the largest principal angle between two subspaces.
+
+    The subspaces are the column spans of ``subspace_a`` and ``subspace_b`` --
+    tall matrices with matching row dimension and orthonormal columns. The value
+    ``||(I - A A^H) B||_2`` is 0 when the spans coincide and 1 when ``B`` has a
+    direction orthogonal to all of ``A``. This is the cluster-level analogue of
+    one minus a wavefunction overlap, robust to eigenvector rotations within a
+    near-degenerate block.
+
+    Parameters
+    ----------
+    subspace_a, subspace_b:
+        Tall matrices with the same number of rows and orthonormal columns; the
+        caller pads them to a common basis first if the cutoffs differ.
+
+    Returns
+    -------
+    The sine of the largest principal angle, clamped to ``[0, 1]``.
+    """
+    residual = subspace_b - subspace_a @ (subspace_a.conj().T @ subspace_b)
+    sin_angle = float(np.linalg.norm(residual, ord=2))
+    return min(1.0, sin_angle)
+
+
+def wavefunction_overlap(
+    c_a: npt.NDArray[np.float64],
+    c_b: npt.NDArray[np.float64],
+    ncut_a: int,
+    ncut_b: int,
+) -> npt.NDArray[np.float64]:
+    """Return per-level wavefunction overlap moduli across two charge cutoffs.
+
+    Both eigenvector arrays are embedded into the larger charge basis (via
+    :func:`pad_charge_basis`) and the modulus of the per-column inner product
+    ``|<a_k | b_k>|`` is returned. The modulus is invariant under each
+    eigenvector's arbitrary global phase, so no phase standardization is needed;
+    a value near 1 means the wavefunction is stable across the cutoff change.
+    This per-level measure is meaningful only for isolated (non-degenerate)
+    levels; near-degenerate clusters must be compared with
+    :func:`subspace_angle`.
+
+    Parameters
+    ----------
+    c_a, c_b:
+        Charge-basis eigenvector arrays (columns are eigenvectors) at cutoffs
+        ``ncut_a`` and ``ncut_b``, with the same number of columns.
+    ncut_a, ncut_b:
+        Charge cutoffs of ``c_a`` and ``c_b``.
+
+    Returns
+    -------
+    The per-level overlap moduli ``|<a_k | b_k>|``, one entry per column.
+    """
+    ncut_max = max(ncut_a, ncut_b)
+    a = pad_charge_basis(c_a, ncut_a, ncut_max)
+    b = pad_charge_basis(c_b, ncut_b, ncut_max)
+    n_cols = a.shape[1]
+    overlaps = np.empty(n_cols, dtype=np.float64)
+    for k in range(n_cols):
+        overlaps[k] = float(np.abs(np.vdot(a[:, k], b[:, k])))
+    return overlaps


### PR DESCRIPTION
## Summary

PR-2 of the convergence framework, **stacked on #295** (base branch
`convergence/pr-1-foundation`, not `main`). Adds the wavefunction and
matrix-element derived channels for `Transmon`, exposed via
`estimate_convergence(include_derived=True, derived_quantities=[...])` and
returned as per-level sub-reports under `ConvergenceReport.derived`.

- `utils/convergence_utils.py`: `pad_charge_basis`, `subspace_angle`,
  `wavefunction_overlap` (pure, unit-tested), plus `geometric_ratio_test`
  factored out of the energy strict-mode path.
- `core/convergence.py`: wavefunction (overlap deficit for isolated levels,
  subspace angle for near-degenerate clusters) and matrix-element (per level,
  the worst relative change of that level's row/column across all operators)
  comparators. Both reuse the refinement eigenvectors/clones (no extra
  diagonalization) and support the strict-mode ratio test; `include_derived`
  inputs are validated.

## Test plan
- [ ] `pytest scqubits/tests/test_convergence.py scqubits/tests/test_convergence_utils.py`
- [ ] `mypy`, `black --check`, and the repo docstring linter clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)