### PR TITLE
Add convergence coherence channel (Transmon)

### DIFF
--- a/scqubits/core/convergence.py
+++ b/scqubits/core/convergence.py
@@ -9,16 +9,16 @@
 #    This source code is licensed under the BSD-style license found in the
 #    LICENSE file in the root directory of this source tree.
 ############################################################################
-"""ConvergenceCheckable mixin and the energy-channel verified-refinement engine.
+"""ConvergenceCheckable mixin and the verified-refinement engine.
 
-PR-1 scope: a concrete qubit that adds ``ConvergenceCheckable`` to its MRO and
-declares ``_convergence_axes`` gains an :meth:`estimate_convergence` method
-returning a :class:`~scqubits.core.convergence_report.ConvergenceReport`.
-Only the energy sub-channel is implemented here; PR-2 adds wavefunctions and
-matrix elements, PR-3 adds coherence.
+A concrete qubit that adds ``ConvergenceCheckable`` to its MRO and declares
+``_convergence_axes`` gains an :meth:`estimate_convergence` method returning a
+:class:`~scqubits.core.convergence_report.ConvergenceReport`. The engine assesses
+the energy spectrum and, on request, the derived wavefunction, matrix-element,
+and coherence channels.
 
-The mixin's refinement engine clones the qubit, bumps a cutoff axis by a
-step, re-diagonalizes, and compares cluster-matched eigenvalues. Cheap-mode
+The refinement engine clones the qubit, bumps a cutoff axis by a step,
+re-diagonalizes, and compares cluster-matched eigenvalues. Cheap-mode
 diagnostics never claim ``converged`` (per the published design specification).
 """
 
@@ -1206,15 +1206,19 @@ def _build_coherence_report(
     ``noise_floor`` warning rather than a lifetime claim. Verdicts use the
     observed-gap ladder against ``target_gap_rel``.
     """
+    safety_factor = settings.CONVERGENCE_SAFETY_FACTOR
     verdicts: list[LevelVerdict] = []
     for idx, name in enumerate(channel_names):
         warnings: tuple[str, ...] = ("noise_floor",) if floor_flags[idx] else ()
+        # One-step rate change times the safety factor, matching the energy and
+        # other derived channels.
+        eps = float(safety_factor * movement[idx])
         verdicts.append(
             LevelVerdict(
                 level_index=idx,
                 status=_assign_status(
                     abs_err_est=0.0,
-                    eps_gap_est=float(movement[idx]),
+                    eps_gap_est=eps,
                     scope="observed_gap_scale",
                     target_abs_GHz=None,
                     target_gap_rel=target_gap_rel,
@@ -1222,7 +1226,7 @@ def _build_coherence_report(
                 status_scope="observed_gap_scale",
                 evidence="verified_empirical",
                 abs_err_est_GHz=None,
-                eps_gap_est=float(movement[idx]),
+                eps_gap_est=eps,
                 truncation_channel=channel,
                 estimator_method=f"{name}_rate",
                 warnings=warnings,

--- a/scqubits/core/convergence.py
+++ b/scqubits/core/convergence.py
@@ -9,7 +9,7 @@
 #    This source code is licensed under the BSD-style license found in the
 #    LICENSE file in the root directory of this source tree.
 ############################################################################
-"""ConvergenceCheckable mixin and the verified-refinement engine.
+"""Verified-refinement convergence diagnostics for qubit classes.
 
 A concrete qubit that adds ``ConvergenceCheckable`` to its MRO and declares
 ``_convergence_axes`` gains an :meth:`estimate_convergence` method returning a

--- a/scqubits/core/convergence.py
+++ b/scqubits/core/convergence.py
@@ -32,6 +32,7 @@ from typing import Any, Sequence
 import numpy as np
 import numpy.typing as npt
 
+import scqubits.core.units as units
 import scqubits.utils.convergence_utils as cutils
 
 from scqubits import settings
@@ -143,8 +144,8 @@ class ConvergenceCheckable:
             ``"verify"`` or ``"strict"`` -- derived quantities need a
             refinement comparison.
         derived_quantities:
-            Subset of ``{"wavefunctions", "matrix_elements"}`` to assess when
-            ``include_derived`` is set. ``"coherence"`` arrives in PR-3.
+            Subset of ``{"wavefunctions", "matrix_elements", "coherence"}`` to
+            assess when ``include_derived`` is set.
         refinement:
             ``"one_step"`` for verify mode; ``"ratio_test"`` for strict
             mode. Coerced to match ``mode`` if inconsistent.
@@ -186,10 +187,8 @@ class ConvergenceCheckable:
             if unknown:
                 raise ValueError(
                     f"unknown derived_quantities: {sorted(unknown)}; valid: "
-                    "'wavefunctions', 'matrix_elements'"
+                    "'wavefunctions', 'matrix_elements', 'coherence'"
                 )
-            if "coherence" in requested_derived:
-                raise NotImplementedError("coherence convergence arrives in PR-3")
         if not self._convergence_axes:
             raise NotImplementedError(
                 f"{type(self).__name__} does not declare _convergence_axes; "
@@ -447,6 +446,7 @@ class ConvergenceCheckable:
             report=report,
             derived_quantities=derived_quantities,
             evals_n0=evals_n0,
+            evals_n1=evals_n1,
             evecs_n0=evecs_n0,
             evecs_n1=evecs_n1,
             evecs_n2=evecs_n2,
@@ -620,6 +620,7 @@ class ConvergenceCheckable:
         report: ConvergenceReport,
         derived_quantities: tuple[str, ...],
         evals_n0: npt.NDArray[np.float64],
+        evals_n1: npt.NDArray[np.float64],
         evecs_n0: npt.NDArray[np.float64],
         evecs_n1: npt.NDArray[np.float64],
         evecs_n2: npt.NDArray[np.float64] | None,
@@ -706,6 +707,33 @@ class ConvergenceCheckable:
                 current_value=ncut_0,
                 step=step,
                 skipped=skipped,
+            )
+
+        if "coherence" in derived_quantities:
+            channels = list(
+                self.effective_noise_channels()  # type: ignore[attr-defined]
+            ) + ["t1_effective", "t2_effective"]
+            names, rate_movement, floor_flags, skipped_channels = (
+                _coherence_rate_movement(
+                    self,
+                    clone_1,
+                    (evals_n0, evecs_n0),
+                    (evals_n1, evecs_n1),
+                    channels,
+                    settings.CONVERGENCE_RATE_FLOOR_HZ,
+                )
+            )
+            derived["coherence"] = _build_coherence_report(
+                channel_names=names,
+                movement=rate_movement,
+                floor_flags=floor_flags,
+                channel=channel,
+                target_gap_rel=target_gap_rel,
+                audit=audit,
+                axis=axis,
+                current_value=ncut_0,
+                step=step,
+                skipped=skipped_channels,
             )
 
         return dataclasses.replace(report, derived=derived)
@@ -1105,6 +1133,122 @@ def _build_metric_report(
         worst_level=worst_idx,
         channel_breakdown_GHz={},
         clusters=clusters,
+        recommendations=recommendations,
+        implementation_audit=audit,
+    )
+
+
+def _coherence_rate_movement(
+    qubit_a: Any,
+    qubit_b: Any,
+    esys_a: tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]],
+    esys_b: tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]],
+    channels: list[str],
+    rate_floor: float,
+) -> tuple[list[str], npt.NDArray[np.float64], list[bool], list[str]]:
+    """Per-channel relative change of noise rates between two cutoffs.
+
+    Each channel's rate is evaluated at both cutoffs (``get_rate=True``, reusing
+    the supplied eigensystems so no extra diagonalization is needed), converted
+    to Hz so that ``rate_floor`` (in Hz) is meaningful regardless of the active
+    unit system, and the relative change ``|G_b - G_a| / max(|G_b|, rate_floor)``
+    is recorded. A channel whose refined rate falls below ``rate_floor`` is
+    flagged -- its rate sits at the noise floor, so the corresponding lifetime is
+    not physically meaningful. Channels that raise are skipped and reported, not
+    silently dropped.
+    """
+    to_hz = units.units_scale_factor()
+    names: list[str] = []
+    movement: list[float] = []
+    floor_flags: list[bool] = []
+    skipped: list[str] = []
+    for channel in channels:
+        try:
+            rate_a = (
+                abs(float(getattr(qubit_a, channel)(get_rate=True, esys=esys_a)))
+                * to_hz
+            )
+            rate_b = (
+                abs(float(getattr(qubit_b, channel)(get_rate=True, esys=esys_b)))
+                * to_hz
+            )
+        except Exception:
+            skipped.append(channel)
+            continue
+        names.append(channel)
+        movement.append(abs(rate_b - rate_a) / max(rate_b, rate_floor))
+        floor_flags.append(rate_b < rate_floor)
+    return names, np.asarray(movement, dtype=np.float64), floor_flags, skipped
+
+
+def _build_coherence_report(
+    channel_names: list[str],
+    movement: npt.NDArray[np.float64],
+    floor_flags: list[bool],
+    channel: TruncationChannel,
+    target_gap_rel: float,
+    audit: ImplementationAudit,
+    axis: str,
+    current_value: int,
+    step: int,
+    skipped: list[str],
+) -> ConvergenceReport:
+    """Assemble the per-noise-channel coherence convergence sub-report.
+
+    Each verdict is one noise channel; ``eps_gap_est`` is the relative change of
+    its rate between cutoffs and ``estimator_method`` names the channel. Rates
+    are assessed first: a channel whose refined rate is below the floor carries a
+    ``noise_floor`` warning rather than a lifetime claim. Verdicts use the
+    observed-gap ladder against ``target_gap_rel``.
+    """
+    verdicts: list[LevelVerdict] = []
+    for idx, name in enumerate(channel_names):
+        warnings: tuple[str, ...] = ("noise_floor",) if floor_flags[idx] else ()
+        verdicts.append(
+            LevelVerdict(
+                level_index=idx,
+                status=_assign_status(
+                    abs_err_est=0.0,
+                    eps_gap_est=float(movement[idx]),
+                    scope="observed_gap_scale",
+                    target_abs_GHz=None,
+                    target_gap_rel=target_gap_rel,
+                ),
+                status_scope="observed_gap_scale",
+                evidence="verified_empirical",
+                abs_err_est_GHz=None,
+                eps_gap_est=float(movement[idx]),
+                truncation_channel=channel,
+                estimator_method=f"{name}_rate",
+                warnings=warnings,
+            )
+        )
+
+    if verdicts:
+        worst_idx, aggregate_status = _aggregate_worst(verdicts)
+    else:
+        worst_idx, aggregate_status = 0, "unverified"
+
+    recommendations: list[str] = []
+    if any(v.status == "underconverged" for v in verdicts):
+        recommendations.append(
+            f"increase {axis} from {current_value} to at least "
+            f"{current_value + step} and re-run; a noise-rate estimate exceeded "
+            f"the target threshold"
+        )
+    if not verdicts:
+        recommendations.append(
+            "no noise-channel rates could be evaluated for this qubit"
+        )
+    if skipped:
+        recommendations.append("skipped noise channels (raised): " + ", ".join(skipped))
+
+    return ConvergenceReport(
+        per_level=verdicts,
+        aggregate_status=aggregate_status,
+        worst_level=worst_idx,
+        channel_breakdown_GHz={},
+        clusters=[],
         recommendations=recommendations,
         implementation_audit=audit,
     )

--- a/scqubits/tests/test_convergence.py
+++ b/scqubits/tests/test_convergence.py
@@ -147,13 +147,6 @@ class TestAPIValidation:
                 n_levels=3, include_derived=True, derived_quantities=["bogus"]
             )
 
-    def test_coherence_derived_not_implemented(self):
-        tmon = sq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
-        with pytest.raises(NotImplementedError, match="coherence"):
-            tmon.estimate_convergence(
-                n_levels=3, include_derived=True, derived_quantities=["coherence"]
-            )
-
 
 # ------------------------------------------------------------- verify-mode tests
 
@@ -376,3 +369,69 @@ class TestDerivedChannels:
         # the successful ratio test or its one-step fallback.
         for v in wf.per_level:
             assert "ratio_test" in v.estimator_method
+
+
+# -------------------------------------------------------------- coherence tests
+
+
+class TestCoherenceChannel:
+    def test_coherence_report_is_per_channel(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = tmon.estimate_convergence(
+            n_levels=4,
+            mode="verify",
+            include_derived=True,
+            derived_quantities=["coherence"],
+        )
+        co = report.derived["coherence"]
+        methods = {v.estimator_method for v in co.per_level}
+        # The qubit's effective noise channels plus the aggregate t1/t2 rates.
+        assert "t1_effective_rate" in methods
+        assert "t2_effective_rate" in methods
+        assert "t1_capacitive_rate" in methods
+        for v in co.per_level:
+            assert v.estimator_method.endswith("_rate")
+            assert v.eps_gap_est is not None
+            # Coherence is a rate metric, not an energy.
+            assert v.abs_err_est_GHz is None
+
+    def test_coherence_converged_at_high_cutoff(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = tmon.estimate_convergence(
+            n_levels=4,
+            mode="verify",
+            include_derived=True,
+            derived_quantities=["coherence"],
+        )
+        assert report.derived["coherence"].aggregate_status == "converged"
+
+    def test_symmetric_zero_channel_flagged_noise_floor(self):
+        # At ng=0 the 1/f charge-noise dephasing rate vanishes by symmetry, so
+        # its rate sits at the noise floor while a real channel does not.
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = tmon.estimate_convergence(
+            n_levels=3,
+            mode="verify",
+            include_derived=True,
+            derived_quantities=["coherence"],
+        )
+        by_method = {
+            v.estimator_method: v for v in report.derived["coherence"].per_level
+        }
+        assert "noise_floor" in by_method["tphi_1_over_f_ng_rate"].warnings
+        assert "noise_floor" not in by_method["t1_capacitive_rate"].warnings
+
+    def test_all_three_derived_channels_together(self):
+        tmon = sq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=31, truncated_dim=6)
+        report = tmon.estimate_convergence(
+            n_levels=3,
+            mode="verify",
+            target_abs_GHz=1e-4,
+            include_derived=True,
+            derived_quantities=["wavefunctions", "matrix_elements", "coherence"],
+        )
+        assert set(report.derived.keys()) == {
+            "wavefunctions",
+            "matrix_elements",
+            "coherence",
+        }

--- a/tools/convergence_validation.py
+++ b/tools/convergence_validation.py
@@ -1,0 +1,273 @@
+"""Numerical validation of the Transmon convergence diagnostics.
+
+Not part of the published package. Establishes that the shipped error estimates
+and verdicts are numerically trustworthy by comparing them against a high-cutoff
+ground truth, across a parameter grid spanning fast and slow charge-basis
+convergence and the charge-degeneracy point.
+
+Methodology note (instability watch): at very large ``ncut`` the diagonalizer's
+own floating-point noise can exceed the truncation error we are trying to
+measure, which would corrupt the ground truth. The script therefore measures the
+ground-truth noise floor (|E(ncut_a) - E(ncut_b)| at two high cutoffs) for every
+parameter set, flags any instability, and only assesses soundness for errors
+clearly above that floor.
+
+Run:  python tools/convergence_validation.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+import scqubits as scq
+import scqubits.core.units as units
+import scqubits.settings as settings
+import scqubits.utils.convergence_utils as cutils
+
+settings.T1_DEFAULT_WARNING = False
+
+NCUT_GT = 200  # ground-truth cutoff
+NCUT_GT_CHECK = 160  # second high cutoff, to gauge the diagonalizer noise floor
+SAFETY = settings.CONVERGENCE_SAFETY_FACTOR
+RATE_FLOOR = settings.CONVERGENCE_RATE_FLOOR_HZ
+
+# (label, EJ, EC, ng): span fast (low EJ/EC) to slow (high EJ/EC) charge-basis
+# convergence, and ng = 0 / 0.25 / 0.5 (the last is the charge-degeneracy point
+# with near-degenerate doublets, exercising the cluster path).
+PARAM_GRID = [
+    ("EJ/EC=67  ng=0   ", 20.0, 0.3, 0.0),
+    ("EJ/EC=67  ng=0.25", 20.0, 0.3, 0.25),
+    ("EJ/EC=67  ng=0.5 ", 20.0, 0.3, 0.5),
+    ("EJ/EC=250 ng=0   ", 50.0, 0.2, 0.0),
+    ("EJ/EC=20  ng=0   ", 10.0, 0.5, 0.0),
+    ("EJ/EC=20  ng=0.5 ", 10.0, 0.5, 0.5),
+    ("EJ/EC=5   ng=0.5 ", 2.5, 0.5, 0.5),
+]
+TEST_NCUTS = [4, 6, 8, 12, 16, 24, 40]
+N_LEVELS = 6
+
+
+def low_evals(EJ, EC, ng, ncut, n):
+    return np.sort(scq.Transmon(EJ=EJ, EC=EC, ng=ng, ncut=ncut).eigenvals(evals_count=n))
+
+
+def ground_truth(EJ, EC, ng, n):
+    """Return (E_exact, noise_floor): the high-cutoff spectrum and the empirical
+    diagonalizer noise floor (max disagreement of low levels at two high cutoffs)."""
+    e_gt = low_evals(EJ, EC, ng, NCUT_GT, n)
+    e_chk = low_evals(EJ, EC, ng, NCUT_GT_CHECK, n)
+    noise = float(np.max(np.abs(e_gt - e_chk)))
+    return e_gt, noise
+
+
+def section(title):
+    print("\n" + "=" * 78)
+    print(title)
+    print("=" * 78)
+
+
+def validate_stability_and_energies():
+    section("GROUND-TRUTH STABILITY (instability watch) + ENERGY SOUNDNESS")
+    worst_ratio = 0.0
+    worst_where = ""
+    violations = 0
+    assessed = 0
+    any_unstable = False
+    for label, EJ, EC, ng in PARAM_GRID:
+        e_gt, noise = ground_truth(EJ, EC, ng, N_LEVELS)
+        unstable = noise > 1e-6
+        any_unstable = any_unstable or unstable
+        flag = "  <-- UNSTABLE GROUND TRUTH" if unstable else ""
+        print(f"\n[{label}] noise floor |E{NCUT_GT_CHECK}-E{NCUT_GT}| = {noise:.2e}{flag}")
+        meaningful = max(10.0 * noise, 1e-9)
+        for ncut in TEST_NCUTS:
+            tmon = scq.Transmon(EJ=EJ, EC=EC, ng=ng, ncut=ncut)
+            rep = tmon.estimate_convergence(n_levels=N_LEVELS, mode="verify")
+            e_now = low_evals(EJ, EC, ng, ncut, N_LEVELS)
+            worst_r = 0.0
+            worst_k = -1
+            for k, v in enumerate(rep.per_level):
+                true_err = abs(float(e_now[k]) - float(e_gt[k]))
+                if true_err <= meaningful:
+                    continue
+                assessed += 1
+                est = v.abs_err_est_GHz or 0.0
+                r = true_err / max(est, 1e-300)
+                if r > worst_r:
+                    worst_r, worst_k = r, k
+                if r > 1.0:
+                    violations += 1
+            if worst_r > worst_ratio:
+                worst_ratio, worst_where = worst_r, f"{label} ncut={ncut} level={worst_k}"
+            tag = "ok" if worst_r <= 1.0 else "UNDERESTIMATE"
+            print(f"   ncut={ncut:3d}: worst true_err/est = {worst_r:6.3f} (level {worst_k})  [{tag}]")
+    print("\n" + "-" * 78)
+    print(f"Energy soundness: {violations} underestimate(s) of {assessed} assessed levels")
+    print(f"Worst true_err/abs_err_est = {worst_ratio:.3f}  at  {worst_where}")
+    print(f"(safety factor S = {SAFETY}; want worst <= 1.0)")
+    return violations == 0 and not any_unstable
+
+
+def validate_verdicts():
+    section("VERDICT SOUNDNESS (no dangerous false 'converged')")
+    false_converged = 0
+    checks = 0
+    for label, EJ, EC, ng in PARAM_GRID:
+        e_gt, noise = ground_truth(EJ, EC, ng, N_LEVELS)
+        tol = 10.0 * noise
+        for ncut in TEST_NCUTS:
+            for target in (1e-2, 1e-4, 1e-6):
+                tmon = scq.Transmon(EJ=EJ, EC=EC, ng=ng, ncut=ncut)
+                rep = tmon.estimate_convergence(
+                    n_levels=N_LEVELS, mode="verify", target_abs_GHz=target
+                )
+                e_now = low_evals(EJ, EC, ng, ncut, N_LEVELS)
+                for k, v in enumerate(rep.per_level):
+                    if v.status != "converged":
+                        continue
+                    checks += 1
+                    true_err = abs(float(e_now[k]) - float(e_gt[k]))
+                    if true_err > target + tol:
+                        false_converged += 1
+                        print(
+                            f"  FALSE CONVERGED: {label} ncut={ncut} level={k} "
+                            f"target={target:.0e} true_err={true_err:.2e}"
+                        )
+    print(f"\nFalse 'converged' verdicts: {false_converged} of {checks} converged-level checks")
+    return false_converged == 0
+
+
+def validate_strict_ratio_test():
+    section("STRICT-MODE RATIO TEST (asymptoticity detection)")
+    # A moderately-converged transmon should be in the geometric regime for the
+    # low levels, so strict mode should reach 'calibrated' evidence.
+    tmon = scq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=16)
+    rep = tmon.estimate_convergence(n_levels=4, mode="strict", target_abs_GHz=1e-6)
+    evid = [v.evidence for v in rep.per_level]
+    methods = [v.estimator_method for v in rep.per_level]
+    calibrated = sum(e == "calibrated" for e in evid)
+    print(f"  evidence: {evid}")
+    print(f"  methods : {methods}")
+    print(f"  {calibrated}/{len(evid)} levels reached 'calibrated' (ratio test asymptotic)")
+    return calibrated >= 1
+
+
+def validate_derived():
+    section("DERIVED CHANNELS vs GROUND TRUTH (ng=0, non-degenerate)")
+    EJ, EC, ng, n = 20.0, 0.3, 0.0, 5
+    gt = scq.Transmon(EJ=EJ, EC=EC, ng=ng, ncut=NCUT_GT)
+    e_gt, evec_gt = gt.eigensys(evals_count=n)
+    to_hz = units.units_scale_factor()
+    all_sound = True
+    for ncut in [6, 10, 16, 24]:
+        tmon = scq.Transmon(EJ=EJ, EC=EC, ng=ng, ncut=ncut)
+        rep = tmon.estimate_convergence(
+            n_levels=n,
+            mode="verify",
+            include_derived=True,
+            derived_quantities=["wavefunctions", "matrix_elements", "coherence"],
+        )
+        e_now, evec_now = tmon.eigensys(evals_count=n)
+
+        true_overlap = cutils.wavefunction_overlap(
+            evec_now[:, :n], evec_gt[:, :n], ncut, NCUT_GT
+        )
+        true_wf = 1.0 - np.minimum(1.0, true_overlap)
+        wf_r = _worst_ratio(true_wf, rep.derived["wavefunctions"])
+
+        true_me = _true_matelem_change(tmon, gt, evec_now, evec_gt, n)
+        me_r = _worst_ratio(true_me, rep.derived["matrix_elements"])
+
+        co_r = 0.0
+        for v in rep.derived["coherence"].per_level:
+            if "noise_floor" in v.warnings:
+                continue  # rate at the noise floor: relative change is meaningless
+            ch = v.estimator_method[:-5]  # strip "_rate"
+            try:
+                r0 = abs(float(getattr(tmon, ch)(get_rate=True, esys=(e_now, evec_now)))) * to_hz
+                r1 = abs(float(getattr(gt, ch)(get_rate=True, esys=(e_gt, evec_gt)))) * to_hz
+            except Exception:
+                continue
+            true_rate = abs(r1 - r0) / max(r1, RATE_FLOOR)
+            if true_rate > 1e-9:
+                co_r = max(co_r, true_rate / max(v.eps_gap_est or 0.0, 1e-300))
+
+        sound = wf_r <= 1.0 and me_r <= 1.0 and co_r <= 1.0
+        all_sound = all_sound and sound
+        print(
+            f"  ncut={ncut:3d}: worst true/reported  wf={wf_r:6.3f}  "
+            f"matrix_elem={me_r:6.3f}  coherence={co_r:6.3f}  "
+            f"[{'ok' if sound else 'UNDERESTIMATE'}]"
+        )
+    return all_sound
+
+
+def _worst_ratio(true_per_level, sub_report):
+    worst = 0.0
+    for k, v in enumerate(sub_report.per_level):
+        if k >= len(true_per_level):
+            break
+        if true_per_level[k] <= 1e-9:
+            continue
+        worst = max(worst, float(true_per_level[k]) / max(v.eps_gap_est or 0.0, 1e-300))
+    return worst
+
+
+def _true_matelem_change(tmon, gt, evec_now, evec_gt, n):
+    movement = np.zeros(n)
+    for op in tmon.get_operator_names():
+        try:
+            m0 = np.asarray(tmon.matrixelement_table(op, evecs=evec_now[:, :n]))
+            m1 = np.asarray(gt.matrixelement_table(op, evecs=evec_gt[:, :n]))
+        except Exception:
+            continue
+        if m0.shape != (n, n) or m1.shape != (n, n):
+            continue
+        d = np.abs(m1 - m0)
+        for k in range(n):
+            row_ref = max(float(np.linalg.norm(m1[k, :])), 1e-12)
+            col_ref = max(float(np.linalg.norm(m1[:, k])), 1e-12)
+            movement[k] = max(
+                movement[k],
+                max(
+                    float(np.linalg.norm(d[k, :])) / row_ref,
+                    float(np.linalg.norm(d[:, k])) / col_ref,
+                ),
+            )
+    return movement
+
+
+def validate_high_cutoff_check():
+    section("CHECK STABILITY AT HIGH CUTOFF (refinement does not blow up)")
+    ok = True
+    for ncut in [60, 100, 150]:
+        tmon = scq.Transmon(EJ=20.0, EC=0.3, ng=0.0, ncut=ncut)
+        rep = tmon.estimate_convergence(n_levels=4, mode="verify", target_abs_GHz=1e-6)
+        worst = max((v.abs_err_est_GHz or 0.0) for v in rep.per_level)
+        status = rep.aggregate_status
+        good = worst < 1e-4 and status == "converged"
+        ok = ok and good
+        print(
+            f"  ncut={ncut:3d}: aggregate={status:11s} worst abs_err_est={worst:.2e}  "
+            f"[{'ok' if good else 'SUSPECT'}]"
+        )
+    return ok
+
+
+def main():
+    results = {
+        "energy soundness + stability": validate_stability_and_energies(),
+        "verdict soundness": validate_verdicts(),
+        "strict ratio test": validate_strict_ratio_test(),
+        "derived channels": validate_derived(),
+        "high-cutoff check stability": validate_high_cutoff_check(),
+    }
+    section("SUMMARY")
+    for name, passed in results.items():
+        print(f"  [{'PASS' if passed else 'FAIL'}]  {name}")
+    print()
+    return 0 if all(results.values()) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

PR-3 of the convergence framework, **stacked on #297** (base branch
`convergence/pr-2-derived`, not `main`). Adds the coherence derived channel for
`Transmon`: per-noise-channel rate-convergence verdicts under
`ConvergenceReport.derived['coherence']`.

- For each channel (the qubit's `effective_noise_channels` plus the aggregate
  `t1_effective` / `t2_effective`), the rate is evaluated at both cutoffs via
  `get_rate=True` (reusing the refinement eigensystems, no extra
  diagonalization), converted to Hz so the Hz noise floor is unit-correct, and
  the relative change is recorded.
- Rates-first: a channel whose rate is below the floor gets a `noise_floor`
  warning instead of a lifetime claim; channels that raise are skipped and
  reported.

Completes the Transmon scope:
`estimate_convergence(include_derived=True, ...)` now covers energies,
wavefunctions, matrix elements, and coherence.

## Test plan
- [ ] `pytest scqubits/tests/test_convergence.py scqubits/tests/test_convergence_utils.py` (54 tests)
- [ ] `mypy`, `black --check`, and the repo docstring linter clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)