### PR TITLE
Add convergence support for Fluxonium (+ basis-agnostic wavefunction hook)

### DIFF
--- a/scqubits/core/convergence.py
+++ b/scqubits/core/convergence.py
@@ -99,6 +99,26 @@ class ConvergenceCheckable:
         """
         return None
 
+    def _convergence_pad_eigenvectors(
+        self,
+        evecs: npt.NDArray[np.float64],
+        value_from: int,
+        value_to: int,
+    ) -> npt.NDArray[np.float64]:
+        """Embed eigenvectors from the basis at one truncation value into a larger one.
+
+        Used by the wavefunction channel to bring two eigenvector sets, computed
+        at different cutoffs, into a common basis before comparison. The
+        embedding is basis-specific (charge bases pad symmetrically, a harmonic
+        oscillator pads at the high-Fock end), so a qubit must override this to
+        support the wavefunction channel; the default signals that the channel is
+        unavailable.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement eigenvector padding, so "
+            "the wavefunction convergence channel is unavailable for it."
+        )
+
     # ----------------------------------------------------------------- public
 
     def estimate_convergence(
@@ -655,12 +675,12 @@ class ConvergenceCheckable:
         derived: dict[str, ConvergenceReport] = {}
 
         if "wavefunctions" in derived_quantities:
-            movement_first = _wavefunction_movement(
+            movement_first = self._convergence_wavefunction_movement(
                 evecs_n0, evecs_n1, ncut_0, ncut_1, clusters, n_levels
             )
             movement_second: npt.NDArray[np.float64] | None = None
             if refinement == "ratio_test" and evecs_n2 is not None:
-                movement_second = _wavefunction_movement(
+                movement_second = self._convergence_wavefunction_movement(
                     evecs_n1, evecs_n2, ncut_1, ncut_2, clusters, n_levels
                 )
             derived["wavefunctions"] = _build_metric_report(
@@ -737,6 +757,42 @@ class ConvergenceCheckable:
             )
 
         return dataclasses.replace(report, derived=derived)
+
+    def _convergence_wavefunction_movement(
+        self,
+        evecs_a: npt.NDArray[np.float64],
+        evecs_b: npt.NDArray[np.float64],
+        value_a: int,
+        value_b: int,
+        clusters: list[tuple[int, ...]],
+        n_levels: int,
+    ) -> npt.NDArray[np.float64]:
+        """Per-level wavefunction movement between two cutoffs.
+
+        Both eigenvector sets are embedded into the larger basis via the
+        qubit's :meth:`_convergence_pad_eigenvectors` hook. Isolated levels use
+        the overlap deficit ``1 - |<a_k | b_k>|`` (invariant to each vector's
+        global phase); near-degenerate clusters use the subspace angle, assigned
+        to every member, which is robust to eigenvector rotations within the
+        block.
+        """
+        value_max = max(value_a, value_b)
+        a = self._convergence_pad_eigenvectors(
+            evecs_a[:, :n_levels], value_a, value_max
+        )
+        b = self._convergence_pad_eigenvectors(
+            evecs_b[:, :n_levels], value_b, value_max
+        )
+        movement = np.empty(n_levels, dtype=np.float64)
+        for k in range(n_levels):
+            movement[k] = 1.0 - min(1.0, abs(complex(np.vdot(a[:, k], b[:, k]))))
+        for cluster in clusters:
+            if len(cluster) > 1:
+                cols = list(cluster)
+                angle = cutils.subspace_angle(a[:, cols], b[:, cols])
+                for k in cluster:
+                    movement[k] = angle
+        return movement
 
 
 # ------------------------------------------------------------ module helpers
@@ -966,36 +1022,6 @@ def _aggregate_worst(verdicts: list[LevelVerdict]) -> tuple[int, Status]:
 _MATELEM_REF_FLOOR = 1e-12
 
 
-def _wavefunction_movement(
-    evecs_a: npt.NDArray[np.float64],
-    evecs_b: npt.NDArray[np.float64],
-    ncut_a: int,
-    ncut_b: int,
-    clusters: list[tuple[int, ...]],
-    n_levels: int,
-) -> npt.NDArray[np.float64]:
-    """Per-level wavefunction movement between two cutoffs.
-
-    Isolated levels use the overlap deficit ``1 - |<a_k | b_k>|``; near-degenerate
-    clusters use the subspace angle (assigned to every member), which is robust to
-    eigenvector rotations within the block.
-    """
-    overlaps = cutils.wavefunction_overlap(
-        evecs_a[:, :n_levels], evecs_b[:, :n_levels], ncut_a, ncut_b
-    )
-    movement = 1.0 - np.minimum(1.0, overlaps)
-    ncut_max = max(ncut_a, ncut_b)
-    a = cutils.pad_charge_basis(evecs_a[:, :n_levels], ncut_a, ncut_max)
-    b = cutils.pad_charge_basis(evecs_b[:, :n_levels], ncut_b, ncut_max)
-    for cluster in clusters:
-        if len(cluster) > 1:
-            cols = list(cluster)
-            angle = cutils.subspace_angle(a[:, cols], b[:, cols])
-            for k in cluster:
-                movement[k] = angle
-    return movement
-
-
 def _matrix_element_movement(
     qubit_a: Any,
     qubit_b: Any,
@@ -1010,8 +1036,11 @@ def _matrix_element_movement(
     assigned the worst relative change of its matrix-element row and column,
     maximized over operators. The relative change normalizes by the refined
     table's row/column norm, floored to guard against selection-rule zeros.
-    Operators that raise or return a shape-incompatible table are skipped and
-    reported (graceful degradation), not silently dropped.
+    Matrix elements are compared by magnitude, since each eigenvector's global
+    phase is a gauge choice that can differ between cutoffs (a signed comparison
+    would report spurious movement from phase flips). Operators that raise or
+    return a shape-incompatible table are skipped and reported (graceful
+    degradation), not silently dropped.
     """
     movement = np.zeros(n_levels, dtype=np.float64)
     skipped: list[str] = []
@@ -1029,7 +1058,7 @@ def _matrix_element_movement(
         if m0.shape != (n_levels, n_levels) or m1.shape != (n_levels, n_levels):
             skipped.append(op_name)
             continue
-        delta = np.abs(m1 - m0)
+        delta = np.abs(np.abs(m1) - np.abs(m0))
         for k in range(n_levels):
             row_ref = max(float(np.linalg.norm(m1[k, :])), _MATELEM_REF_FLOOR)
             col_ref = max(float(np.linalg.norm(m1[:, k])), _MATELEM_REF_FLOOR)

--- a/scqubits/core/fluxonium.py
+++ b/scqubits/core/fluxonium.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import numpy.typing as npt
 import scipy as sp
 
 from numpy import ndarray
@@ -32,13 +33,17 @@ import scqubits.core.qubit_base as base
 import scqubits.core.storage as storage
 import scqubits.io_utils.fileio_serializers as serializers
 
+from scqubits.core.convergence import ConvergenceCheckable
+from scqubits.core.convergence_report import TruncationChannel
 from scqubits.core.noise import NoisySystem
 
 if TYPE_CHECKING:
     from scqubits.core.discretization import Grid1d
 
 
-class Fluxonium(base.QubitBaseClass1d, serializers.Serializable, NoisySystem):
+class Fluxonium(
+    base.QubitBaseClass1d, serializers.Serializable, NoisySystem, ConvergenceCheckable
+):
     r"""Class for the fluxonium qubit.
 
     Hamiltonian :math:`H_\text{fl}=-4E_\text{C}\partial_\phi^2-E_\text{J}\cos(
@@ -81,6 +86,9 @@ class Fluxonium(base.QubitBaseClass1d, serializers.Serializable, NoisySystem):
     EL = descriptors.WatchedProperty(float, "QUANTUMSYSTEM_UPDATE")
     flux = descriptors.WatchedProperty(float, "QUANTUMSYSTEM_UPDATE")
     cutoff = descriptors.WatchedProperty(int, "QUANTUMSYSTEM_UPDATE")
+
+    _convergence_axes: tuple[str, ...] = ("cutoff",)
+    _convergence_basis: str = "harmonic_osc"
 
     def __init__(
         self,
@@ -143,6 +151,51 @@ class Fluxonium(base.QubitBaseClass1d, serializers.Serializable, NoisySystem):
         noise_channels = cls.supported_noise_channels()
         noise_channels.remove("t1_charge_impedance")
         return noise_channels
+
+    # ----- Convergence-diagnostics hooks ----------------------------------------------
+
+    def _convergence_truncation_channel(self, axis: str) -> TruncationChannel:
+        """Report the harmonic-oscillator phi channel for the ``cutoff`` axis."""
+        return "HO_phi"
+
+    def _convergence_boundary_diagnostic(
+        self,
+        esys: tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]],
+        axis: str,
+    ) -> npt.NDArray[np.float64] | None:
+        """Per-level boundary-amplitude cheap diagnostic for ``cutoff``.
+
+        Returns the squared amplitude in the highest harmonic-oscillator basis
+        state, ``|c_{cutoff-1, k}|^2``, for each kept level ``k``. Large values
+        signal appreciable support at the top of the kept Fock space and so an
+        underconverged eigenstate; quick mode promotes a level out of
+        ``unverified`` only when this is well below a small threshold. Returns
+        ``None`` if ``axis`` is not ``"cutoff"``.
+        """
+        if axis != "cutoff":
+            return None
+        _, evecs = esys
+        return (np.abs(evecs[-1, :]) ** 2).astype(np.float64)
+
+    def _convergence_pad_eigenvectors(
+        self,
+        evecs: npt.NDArray[np.float64],
+        value_from: int,
+        value_to: int,
+    ) -> npt.NDArray[np.float64]:
+        """Zero-pad harmonic-oscillator eigenvectors to a larger ``cutoff``.
+
+        The Fock basis is ordered ``0 .. cutoff-1``; embedding into a larger
+        cutoff appends zero rows for the added high-Fock states.
+        """
+        if value_to < value_from:
+            raise ValueError(
+                f"value_to ({value_to}) must be >= value_from ({value_from})"
+            )
+        pad = value_to - value_from
+        if pad == 0:
+            return evecs
+        return np.pad(evecs, ((0, pad), (0, 0)))
 
     def phi_osc(self) -> float:
         """Return the oscillator length for the fluxonium LC oscillator."""

--- a/scqubits/core/transmon.py
+++ b/scqubits/core/transmon.py
@@ -40,6 +40,7 @@ from scqubits.core.convergence_report import TruncationChannel
 from scqubits.core.discretization import Grid1d
 from scqubits.core.noise import NoisySystem
 from scqubits.core.storage import WaveFunction
+from scqubits.utils.convergence_utils import pad_charge_basis
 
 LevelsTuple = tuple[int, ...]
 Transition = tuple[int, int]
@@ -183,6 +184,19 @@ class Transmon(
         # k-th eigenvector.
         boundary_sq = np.abs(evecs[0, :]) ** 2 + np.abs(evecs[-1, :]) ** 2
         return boundary_sq.astype(np.float64)
+
+    def _convergence_pad_eigenvectors(
+        self,
+        evecs: npt.NDArray[np.float64],
+        value_from: int,
+        value_to: int,
+    ) -> npt.NDArray[np.float64]:
+        """Symmetrically zero-pad charge-basis eigenvectors to a larger ``ncut``.
+
+        The charge basis spans ``n = -ncut .. +ncut``; embedding into a larger
+        cutoff adds equal zero rows at each end, keeping ``n = 0`` centered.
+        """
+        return pad_charge_basis(evecs, value_from, value_to)
 
     def _hamiltonian_diagonal(self) -> npt.NDArray[np.float64]:
         """Return the diagonal of the Hamiltonian in the charge basis."""

--- a/scqubits/tests/test_convergence.py
+++ b/scqubits/tests/test_convergence.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import dataclasses
 
+import numpy as np
 import pytest
 
 import scqubits as sq
@@ -472,3 +473,48 @@ class TestTunableTransmon:
         )
         report = tt.estimate_convergence(n_levels=5, mode="verify", target_abs_GHz=1e-8)
         assert report.aggregate_status in {"marginal", "underconverged"}
+
+
+# ------------------------------------------------------------- Fluxonium (Stage 2)
+
+
+class TestFluxonium:
+    def test_all_channels_converge(self):
+        # Fluxonium uses a harmonic-oscillator (Fock) basis controlled by cutoff.
+        flx = sq.Fluxonium(
+            EJ=8.9, EC=2.5, EL=0.5, flux=0.5, cutoff=110, truncated_dim=6
+        )
+        report = flx.estimate_convergence(
+            n_levels=5,
+            mode="verify",
+            target_abs_GHz=1e-4,
+            include_derived=True,
+            derived_quantities=["wavefunctions", "matrix_elements", "coherence"],
+        )
+        assert report.aggregate_status == "converged"
+        # The truncation channel is the HO phi coordinate, not charge.
+        assert report.per_level[0].truncation_channel == "HO_phi"
+        assert report.implementation_audit.qubit_class == "Fluxonium"
+        assert report.implementation_audit.cutoff_parameters == {"cutoff": 110}
+        for sub in report.derived.values():
+            assert sub.aggregate_status == "converged"
+
+    def test_undersized_is_underconverged(self):
+        flx = sq.Fluxonium(EJ=8.9, EC=2.5, EL=0.5, flux=0.5, cutoff=12, truncated_dim=6)
+        report = flx.estimate_convergence(
+            n_levels=5, mode="verify", target_abs_GHz=1e-8
+        )
+        assert report.aggregate_status in {"marginal", "underconverged"}
+        assert any("cutoff" in r for r in report.recommendations)
+
+    def test_pad_eigenvectors_appends_high_fock_zeros(self):
+        flx = sq.Fluxonium(EJ=8.9, EC=2.5, EL=0.5, flux=0.5, cutoff=20, truncated_dim=6)
+        evecs = np.zeros((20, 2), dtype=np.float64)
+        evecs[0, 0] = 1.0
+        evecs[5, 1] = 1.0
+        padded = flx._convergence_pad_eigenvectors(evecs, 20, 30)
+        assert padded.shape == (30, 2)
+        # Existing Fock amplitudes are preserved; the added high-Fock rows are 0.
+        assert padded[0, 0] == 1.0
+        assert padded[5, 1] == 1.0
+        assert np.all(padded[20:, :] == 0.0)

--- a/tools/convergence_validation.py
+++ b/tools/convergence_validation.py
@@ -48,7 +48,9 @@ N_LEVELS = 6
 
 
 def low_evals(EJ, EC, ng, ncut, n):
-    return np.sort(scq.Transmon(EJ=EJ, EC=EC, ng=ng, ncut=ncut).eigenvals(evals_count=n))
+    return np.sort(
+        scq.Transmon(EJ=EJ, EC=EC, ng=ng, ncut=ncut).eigenvals(evals_count=n)
+    )
 
 
 def ground_truth(EJ, EC, ng, n):
@@ -78,7 +80,9 @@ def validate_stability_and_energies():
         unstable = noise > 1e-6
         any_unstable = any_unstable or unstable
         flag = "  <-- UNSTABLE GROUND TRUTH" if unstable else ""
-        print(f"\n[{label}] noise floor |E{NCUT_GT_CHECK}-E{NCUT_GT}| = {noise:.2e}{flag}")
+        print(
+            f"\n[{label}] noise floor |E{NCUT_GT_CHECK}-E{NCUT_GT}| = {noise:.2e}{flag}"
+        )
         meaningful = max(10.0 * noise, 1e-9)
         for ncut in TEST_NCUTS:
             tmon = scq.Transmon(EJ=EJ, EC=EC, ng=ng, ncut=ncut)
@@ -98,11 +102,18 @@ def validate_stability_and_energies():
                 if r > 1.0:
                     violations += 1
             if worst_r > worst_ratio:
-                worst_ratio, worst_where = worst_r, f"{label} ncut={ncut} level={worst_k}"
+                worst_ratio, worst_where = (
+                    worst_r,
+                    f"{label} ncut={ncut} level={worst_k}",
+                )
             tag = "ok" if worst_r <= 1.0 else "UNDERESTIMATE"
-            print(f"   ncut={ncut:3d}: worst true_err/est = {worst_r:6.3f} (level {worst_k})  [{tag}]")
+            print(
+                f"   ncut={ncut:3d}: worst true_err/est = {worst_r:6.3f} (level {worst_k})  [{tag}]"
+            )
     print("\n" + "-" * 78)
-    print(f"Energy soundness: {violations} underestimate(s) of {assessed} assessed levels")
+    print(
+        f"Energy soundness: {violations} underestimate(s) of {assessed} assessed levels"
+    )
     print(f"Worst true_err/abs_err_est = {worst_ratio:.3f}  at  {worst_where}")
     print(f"(safety factor S = {SAFETY}; want worst <= 1.0)")
     return violations == 0 and not any_unstable
@@ -133,7 +144,9 @@ def validate_verdicts():
                             f"  FALSE CONVERGED: {label} ncut={ncut} level={k} "
                             f"target={target:.0e} true_err={true_err:.2e}"
                         )
-    print(f"\nFalse 'converged' verdicts: {false_converged} of {checks} converged-level checks")
+    print(
+        f"\nFalse 'converged' verdicts: {false_converged} of {checks} converged-level checks"
+    )
     return false_converged == 0
 
 
@@ -148,7 +161,9 @@ def validate_strict_ratio_test():
     calibrated = sum(e == "calibrated" for e in evid)
     print(f"  evidence: {evid}")
     print(f"  methods : {methods}")
-    print(f"  {calibrated}/{len(evid)} levels reached 'calibrated' (ratio test asymptotic)")
+    print(
+        f"  {calibrated}/{len(evid)} levels reached 'calibrated' (ratio test asymptotic)"
+    )
     return calibrated >= 1
 
 
@@ -184,8 +199,14 @@ def validate_derived():
                 continue  # rate at the noise floor: relative change is meaningless
             ch = v.estimator_method[:-5]  # strip "_rate"
             try:
-                r0 = abs(float(getattr(tmon, ch)(get_rate=True, esys=(e_now, evec_now)))) * to_hz
-                r1 = abs(float(getattr(gt, ch)(get_rate=True, esys=(e_gt, evec_gt)))) * to_hz
+                r0 = (
+                    abs(float(getattr(tmon, ch)(get_rate=True, esys=(e_now, evec_now))))
+                    * to_hz
+                )
+                r1 = (
+                    abs(float(getattr(gt, ch)(get_rate=True, esys=(e_gt, evec_gt))))
+                    * to_hz
+                )
             except Exception:
                 continue
             true_rate = abs(r1 - r0) / max(r1, RATE_FLOOR)
@@ -223,7 +244,10 @@ def _true_matelem_change(tmon, gt, evec_now, evec_gt, n):
             continue
         if m0.shape != (n, n) or m1.shape != (n, n):
             continue
-        d = np.abs(m1 - m0)
+        # Compare matrix-element magnitudes: each eigenvector's global phase is a
+        # gauge choice that can flip between cutoffs, matching the framework's
+        # phase-invariant comparison in _matrix_element_movement.
+        d = np.abs(np.abs(m1) - np.abs(m0))
         for k in range(n):
             row_ref = max(float(np.linalg.norm(m1[k, :])), 1e-12)
             col_ref = max(float(np.linalg.norm(m1[:, k])), 1e-12)


### PR DESCRIPTION
## Summary

Stage 2 of the convergence framework, **stacked on #299** (base branch
`convergence/pr-4-tunable-transmon`, not `main`). Extends convergence checking
to `Fluxonium` and generalizes the wavefunction channel beyond the transmon
charge basis.

- **Basis-agnostic wavefunction hook.** New per-qubit
  `_convergence_pad_eigenvectors` hook (default raises). The wavefunction channel
  embeds eigenvectors through the hook instead of a hard-coded charge pad.
  Transmon overrides it with symmetric charge padding; Fluxonium with high-Fock
  zero padding. Energy/matrix-element/coherence channels were already
  basis-agnostic.
- **Fluxonium opt-in.** `ConvergenceCheckable` in the MRO,
  `_convergence_axes = ("cutoff",)`, `HO_phi` truncation channel, and a
  top-Fock boundary diagnostic for quick mode.
- **Phase-invariant matrix elements.** Compare `|<i|Op|j>|` rather than signed
  values: each eigenvector's global phase is a gauge choice that can flip between
  cutoffs. Fluxonium exposed this as a spurious 2x "movement" on a fully
  converged spectrum (Transmon happened to get consistent phases). The
  numerical-validation script is updated to match.

All four channels converge for Fluxonium; the Transmon numerical validation
still passes (5/5 sections).

## Test plan
- [ ] `pytest scqubits/tests/test_convergence.py -k Fluxonium`
- [ ] full convergence suite (59 tests) + `mypy` / `black` / docstring-lint clean
- [ ] `python tools/convergence_validation.py` (Transmon) all sections PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)