### PR TITLE
fix(multiprocessing): effective BLAS cap on fork, pool lifecycle, autotuner & doc fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ gui = [
 develop = [
     "pytest", "traitlets", "h5py (>=2.10)",
     "mypy", "types-tqdm", "scipy-stubs==1.15.2.2",
+    "threadpoolctl",
 ]
 
 [project.urls]
@@ -106,5 +107,7 @@ module = [
     "qutip.*",
     "sympy",
     "sympy.*",
+    # Optional BLAS-thread limiter used by cpu_switch for fork-based worker caps
+    "threadpoolctl",
 ]
 ignore_missing_imports = true

--- a/scqubits/core/param_sweep.py
+++ b/scqubits/core/param_sweep.py
@@ -1681,6 +1681,17 @@ class ParameterSweep(
         Pair of :class:`NamedSlotsNdarray` instances with axes
         ``[<paramname1>, <paramname2>, ...]`` containing dressed eigenvalues
         and dressed eigenvectors, respectively.
+
+        Notes
+        -----
+        While the grid is being mapped, ``self._data["bare_evals"]``,
+        ``self._data["bare_evecs"]`` and ``self._data["circuit_esys"]`` are
+        temporarily set to ``None`` (restored in a ``finally`` block) so that the
+        bound worker callable does not pickle the whole grid's bare spectrum into
+        every task. A user-supplied ``update_hilbertspace`` callback must therefore
+        not read these ``self._data`` entries: it receives the parameter values it
+        needs as arguments, and the per-point bare eigensystem is delivered to the
+        worker through the work item instead.
         """
         target_map = cpu_switch.get_map_method(self._num_cpus)
         total_count = int(np.prod(self._parameters.counts))
@@ -1689,7 +1700,9 @@ class ParameterSweep(
         # Reading these slices from ``self._data`` inside the worker would pickle
         # the whole grid's bare-spectrum arrays into every task (O(N^2) IPC), so
         # detach them here, pass per-point slices through the work items, and
-        # restore ``self._data`` afterwards.
+        # restore ``self._data`` afterwards. While detached, these three entries
+        # are ``None``; a user ``update_hilbertspace`` callback must not read them
+        # (see the Notes in this method's docstring).
         bare_evals = self._data["bare_evals"]
         bare_evecs = self._data["bare_evecs"]
         circuit_esys = self._data["circuit_esys"]
@@ -1715,7 +1728,9 @@ class ParameterSweep(
         self._data["circuit_esys"] = None
         try:
             with utils.InfoBar(
-                "Parallel compute dressed eigensys [num_cpus={}]".format(self._num_cpus),
+                "Parallel compute dressed eigensys [num_cpus={}]".format(
+                    self._num_cpus
+                ),
                 self._num_cpus,
             ) as p:
                 spectrum_data = list(

--- a/scqubits/settings.py
+++ b/scqubits/settings.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import warnings
 
-from typing import Any, Type
+from typing import Any, Optional, Type
 
 import matplotlib.font_manager as mpl_font
 import numpy as np
@@ -96,13 +96,23 @@ NUM_CPUS = 1
 MULTIPROC = "pathos"
 
 # Cap BLAS/OpenMP threads *per worker process* during parallel sweeps
-# (num_cpus > 1). With the default (None) the environment is left untouched. When
-# many small diagonalizations are swept, the worker processes and the BLAS thread
-# pool otherwise oversubscribe the cores (num_cpus x BLAS-threads >> physical
-# cores); setting this to a small value (e.g. 1, or cores // num_cpus) avoids that.
-# Only affects worker pools created here, and only takes effect for spawn-based
-# workers that re-import numpy (the default on Windows).
-MULTIPROC_BLAS_THREADS: Any = None
+# (num_cpus > 1). Must be a positive int or None; with the default (None) the
+# environment is left untouched. When many small diagonalizations are swept, the
+# worker processes and the BLAS thread pool otherwise oversubscribe the cores
+# (num_cpus x BLAS-threads >> physical cores); setting this to a small value
+# (e.g. 1, or cores // num_cpus) avoids that.
+#
+# IMPORTANT - this only takes effect for SPAWN-based workers whose numpy links
+# against OpenBLAS or MKL. It has no effect when:
+#   - workers are fork-based (the pathos/multiprocessing default on Linux, and on
+#     macOS where the pathos backend forces fork): forked workers inherit the
+#     parent's already-initialized BLAS thread pool and never re-read these vars;
+#   - numpy links against Apple Accelerate (the default on Apple Silicon), which
+#     ignores these environment variables entirely.
+# On those platforms, cap BLAS threads instead by exporting OPENBLAS_NUM_THREADS
+# (etc.) in the shell *before* importing scqubits/numpy. The cap is applied only
+# while the worker pool is created; the parent environment is restored afterwards.
+MULTIPROC_BLAS_THREADS: Optional[int] = None
 
 # Matplotlib options -------------------------------------------------------------------
 # select fonts

--- a/scqubits/tests/test_cpu_switch.py
+++ b/scqubits/tests/test_cpu_switch.py
@@ -1,0 +1,137 @@
+# test_cpu_switch.py
+# meant to be run with 'pytest'
+#
+# This file is part of scqubits: a Python package for superconducting qubits,
+# Quantum 5, 583 (2021). https://quantum-journal.org/papers/q-2021-11-17-583/
+#
+#    Copyright (c) 2019 and later, Jens Koch and Peter Groszkowski
+#    All rights reserved.
+#
+#    This source code is licensed under the BSD-style license found in the
+#    LICENSE file in the root directory of this source tree.
+############################################################################
+
+import os
+
+import pytest
+
+import scqubits.settings as settings
+import scqubits.utils.cpu_switch as cpu_switch
+
+from scqubits.utils.cpu_switch import (
+    _BLAS_THREAD_ENV_VARS,
+    _capped_blas_threads,
+    _validated_blas_thread_cap,
+)
+
+
+class TestValidatedBlasThreadCap:
+    def test_none_returns_none(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", None)
+        assert _validated_blas_thread_cap() is None
+
+    def test_positive_int_passes_through(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 3)
+        assert _validated_blas_thread_cap() == 3
+
+    @pytest.mark.parametrize("bad", [1.5, "2", [1], 2.0])
+    def test_non_int_rejected(self, monkeypatch, bad):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", bad)
+        with pytest.raises(TypeError):
+            _validated_blas_thread_cap()
+
+    def test_bool_rejected(self, monkeypatch):
+        # bool is an int subclass; True must not be silently treated as 1
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", True)
+        with pytest.raises(TypeError):
+            _validated_blas_thread_cap()
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_non_positive_rejected(self, monkeypatch, bad):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", bad)
+        with pytest.raises(ValueError):
+            _validated_blas_thread_cap()
+
+
+class TestCappedBlasThreads:
+    def test_noop_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", None)
+        monkeypatch.delenv("OPENBLAS_NUM_THREADS", raising=False)
+        with _capped_blas_threads():
+            assert "OPENBLAS_NUM_THREADS" not in os.environ
+
+    def test_sets_cap_inside_and_removes_after_when_unset_before(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 2)
+        for var in _BLAS_THREAD_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        with _capped_blas_threads():
+            for var in _BLAS_THREAD_ENV_VARS:
+                assert os.environ[var] == "2"
+        # vars that were unset before the block must be removed again
+        for var in _BLAS_THREAD_ENV_VARS:
+            assert var not in os.environ
+
+    def test_restores_preexisting_value(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 1)
+        monkeypatch.setenv("OPENBLAS_NUM_THREADS", "7")
+        with _capped_blas_threads():
+            assert os.environ["OPENBLAS_NUM_THREADS"] == "1"
+        # a value present before the block must be restored, not deleted
+        assert os.environ["OPENBLAS_NUM_THREADS"] == "7"
+
+    def test_restores_environment_on_exception(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 1)
+        monkeypatch.delenv("OPENBLAS_NUM_THREADS", raising=False)
+        with pytest.raises(RuntimeError):
+            with _capped_blas_threads():
+                raise RuntimeError("boom")
+        assert "OPENBLAS_NUM_THREADS" not in os.environ
+
+
+class TestShutdownCachedPool:
+    def test_noop_when_no_pool(self, monkeypatch):
+        monkeypatch.setattr(settings, "POOL", None)
+        cpu_switch._shutdown_cached_pool()  # must not raise
+        assert settings.POOL is None
+
+    def test_shuts_down_and_clears_cached_pool(self, monkeypatch):
+        class FakePool:
+            def __init__(self):
+                self.terminated = False
+
+            def terminate(self):
+                self.terminated = True
+
+            def close(self):
+                pass
+
+            def clear(self):
+                pass
+
+        pool = FakePool()
+        monkeypatch.setattr(settings, "POOL", pool)
+        cpu_switch._shutdown_cached_pool()
+        assert pool.terminated is True
+        assert settings.POOL is None
+
+
+class TestShutdownPool:
+    def test_cleanup_failure_is_logged_not_raised(self, caplog):
+        class BadPool:
+            def terminate(self):
+                raise RuntimeError("boom")
+
+            def close(self):
+                pass
+
+            def clear(self):
+                pass
+
+        with caplog.at_level("WARNING"):
+            cpu_switch._shutdown_pool(BadPool())  # must not raise
+        assert any("cleanup" in record.message for record in caplog.records)
+
+
+class TestGetMapMethodSerial:
+    def test_num_cpus_one_returns_builtin_map(self):
+        assert cpu_switch.get_map_method(1) is map

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 import atexit
 import logging
 import os
+import warnings
 
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
-from typing import Optional
+from contextlib import contextmanager, nullcontext
+from typing import Any, ContextManager, Optional
 
 import scqubits.settings as settings
 
@@ -31,6 +32,9 @@ _BLAS_THREAD_ENV_VARS = (
     "OMP_NUM_THREADS",
     "NUMEXPR_NUM_THREADS",
 )
+
+# The "BLAS-thread cap cannot take effect" warning is emitted at most once.
+_blas_cap_ineffective_warned = False
 
 
 def get_map_method(num_cpus: int) -> Callable:
@@ -132,26 +136,110 @@ def _validated_blas_thread_cap() -> Optional[int]:
     return threads
 
 
+def _import_threadpoolctl() -> Optional[Any]:
+    """Return the ``threadpoolctl`` module if installed, else ``None``."""
+    try:
+        import threadpoolctl
+    except ImportError:
+        return None
+    return threadpoolctl
+
+
+def _worker_start_method() -> str:
+    """Return the process start method of the configured multiprocessing backend.
+
+    Returns
+    -------
+    ``'fork'``, ``'spawn'``, ``'forkserver'``, or ``''`` if it cannot be queried.
+    The pathos backend uses ``multiprocess``, whose default can differ from the
+    standard-library ``multiprocessing`` default (notably fork on macOS).
+    """
+    module_name = (
+        "multiprocess" if settings.MULTIPROC == "pathos" else "multiprocessing"
+    )
+    try:
+        import importlib
+
+        return importlib.import_module(module_name).get_start_method() or ""
+    except Exception:
+        return ""
+
+
+def _warn_blas_cap_ineffective(threads: int) -> None:
+    """Warn (once) when the requested BLAS-thread cap cannot take effect.
+
+    Capping relies on either ``threadpoolctl`` (which retunes OpenBLAS/MKL/OpenMP
+    in the parent before workers fork) or spawn-based workers that re-read the
+    environment. It cannot work when numpy's BLAS exposes no controller (e.g. Apple
+    Accelerate) or when workers are fork-based and ``threadpoolctl`` is unavailable.
+
+    Parameters
+    ----------
+    threads:
+        the requested per-worker thread cap, used only in the warning message.
+    """
+    global _blas_cap_ineffective_warned
+    if _blas_cap_ineffective_warned:
+        return
+    threadpoolctl = _import_threadpoolctl()
+    reason = ""
+    if threadpoolctl is not None:
+        if not threadpoolctl.threadpool_info():
+            reason = (
+                "numpy's BLAS backend exposes no thread control (e.g. Apple "
+                "Accelerate)"
+            )
+    elif _worker_start_method() == "fork":
+        reason = (
+            "workers are fork-based and 'threadpoolctl' is not installed; install "
+            "it (pip install threadpoolctl) to cap threads in forked workers, or "
+            "export OPENBLAS_NUM_THREADS/MKL_NUM_THREADS before importing scqubits"
+        )
+    if reason:
+        warnings.warn(
+            "settings.MULTIPROC_BLAS_THREADS={} has no effect here: {}.".format(
+                threads, reason
+            ),
+            stacklevel=3,
+        )
+        _blas_cap_ineffective_warned = True
+
+
 @contextmanager
 def _capped_blas_threads() -> Iterator[None]:
-    """Temporarily cap worker BLAS/OpenMP threads via the environment.
+    """Temporarily cap worker BLAS/OpenMP threads while a pool is created.
 
-    The thread-count environment variables are set on entry and restored to their
-    prior values on exit, so the cap applies only to worker processes created
-    inside the ``with`` block (they capture the capped environment as they fork or
-    spawn) and never permanently alters the parent process's environment. No-op
-    when ``settings.MULTIPROC_BLAS_THREADS`` is ``None``.
+    Two mechanisms are combined so the cap reaches workers regardless of start
+    method:
+
+    - the thread-count environment variables are set on entry and restored on
+      exit, which spawn-based workers re-read when they re-import numpy;
+    - if ``threadpoolctl`` is installed, the parent's BLAS/OpenMP thread count is
+      limited for the duration of the block, so fork-based workers inherit the
+      reduced count.
+
+    Neither the parent environment nor its thread-pool settings are altered after
+    the block exits. No-op when ``settings.MULTIPROC_BLAS_THREADS`` is ``None``; a
+    warning is emitted when the cap cannot take effect on the current platform.
     """
     threads = _validated_blas_thread_cap()
     if threads is None:
         yield
         return
+    _warn_blas_cap_ineffective(threads)
     value = str(threads)
     saved = {var: os.environ.get(var) for var in _BLAS_THREAD_ENV_VARS}
     for var in _BLAS_THREAD_ENV_VARS:
         os.environ[var] = value
+    threadpoolctl = _import_threadpoolctl()
+    limiter: ContextManager[Any] = (
+        threadpoolctl.threadpool_limits(limits=threads)
+        if threadpoolctl is not None
+        else nullcontext()
+    )
     try:
-        yield
+        with limiter:
+            yield
     finally:
         for var, original in saved.items():
             if original is None:

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -12,11 +12,25 @@
 
 from __future__ import annotations
 
+import atexit
+import logging
 import os
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Optional
 
 import scqubits.settings as settings
+
+LOGGER = logging.getLogger(__name__)
+
+# Environment variables read by the common BLAS/OpenMP backends at numpy import.
+_BLAS_THREAD_ENV_VARS = (
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OMP_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+)
 
 
 def get_map_method(num_cpus: int) -> Callable:
@@ -68,7 +82,17 @@ def _pool_is_reusable(pool: object, num_cpus: int) -> bool:
 
 
 def _shutdown_pool(pool: object) -> None:
-    """Terminate a pool that is about to be discarded; never raise on cleanup."""
+    """Terminate a pool that is about to be discarded.
+
+    Cleanup failures are logged rather than raised, so discarding a pool never
+    interrupts the caller, while a failure that could leak worker processes still
+    leaves a diagnostic trail.
+
+    Parameters
+    ----------
+    pool:
+        pool object to shut down; missing cleanup methods are skipped.
+    """
     for method_name in ("terminate", "close", "clear"):
         method = getattr(pool, method_name, None)
         if method is None:
@@ -76,50 +100,114 @@ def _shutdown_pool(pool: object) -> None:
         try:
             method()
         except Exception:
-            pass
+            LOGGER.warning(
+                "scqubits: worker-pool cleanup via %s() failed; worker processes "
+                "may linger.",
+                method_name,
+                exc_info=True,
+            )
 
 
-def _apply_blas_thread_cap() -> None:
-    """Cap worker BLAS/OpenMP threads via the environment before workers spawn.
+def _validated_blas_thread_cap() -> Optional[int]:
+    """Return the validated ``settings.MULTIPROC_BLAS_THREADS`` value.
 
-    Spawn-based workers (the default on Windows) re-import numpy and read these
-    variables at import, so capping here keeps ``num_cpus`` workers from each
-    launching a full BLAS thread pool and oversubscribing the cores. No-op when
-    ``settings.MULTIPROC_BLAS_THREADS`` is ``None``.
+    Returns
+    -------
+    The configured positive thread cap, or ``None`` when capping is disabled.
     """
     threads = getattr(settings, "MULTIPROC_BLAS_THREADS", None)
     if threads is None:
+        return None
+    # bool is an int subclass; reject it explicitly to avoid True -> 1 surprises.
+    if isinstance(threads, bool) or not isinstance(threads, int):
+        raise TypeError(
+            "settings.MULTIPROC_BLAS_THREADS must be a positive int or None, got "
+            "{!r}".format(threads)
+        )
+    if threads < 1:
+        raise ValueError(
+            "settings.MULTIPROC_BLAS_THREADS must be a positive int or None, got "
+            "{}".format(threads)
+        )
+    return threads
+
+
+@contextmanager
+def _capped_blas_threads() -> Iterator[None]:
+    """Temporarily cap worker BLAS/OpenMP threads via the environment.
+
+    The thread-count environment variables are set on entry and restored to their
+    prior values on exit, so the cap applies only to worker processes created
+    inside the ``with`` block (they capture the capped environment as they fork or
+    spawn) and never permanently alters the parent process's environment. No-op
+    when ``settings.MULTIPROC_BLAS_THREADS`` is ``None``.
+    """
+    threads = _validated_blas_thread_cap()
+    if threads is None:
+        yield
         return
-    value = str(int(threads))
-    for var in (
-        "OPENBLAS_NUM_THREADS",
-        "MKL_NUM_THREADS",
-        "OMP_NUM_THREADS",
-        "NUMEXPR_NUM_THREADS",
-    ):
+    value = str(threads)
+    saved = {var: os.environ.get(var) for var in _BLAS_THREAD_ENV_VARS}
+    for var in _BLAS_THREAD_ENV_VARS:
         os.environ[var] = value
+    try:
+        yield
+    finally:
+        for var, original in saved.items():
+            if original is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = original
 
 
 def _new_pool(num_cpus: int) -> object:
-    """Start a fresh pool of the configured kind."""
-    _apply_blas_thread_cap()
-    if settings.MULTIPROC == "pathos":
-        try:
-            import dill
-            import pathos
-        except ImportError:
-            raise ImportError(
-                "scqubits multiprocessing mode set to 'pathos'. Need but cannot find"
-                " 'pathos'/'dill'!"
-            )
-        dill.settings["recurse"] = True
-        return pathos.pools.ProcessPool(nodes=num_cpus)
-    if settings.MULTIPROC == "multiprocessing":
-        import multiprocessing
+    """Start a fresh pool of the configured kind.
 
-        return multiprocessing.Pool(processes=num_cpus)
+    The BLAS/OpenMP thread cap is applied only while the worker processes are
+    created (they capture the capped environment as they spawn or fork); the parent
+    process's environment is restored immediately afterwards.
+
+    Parameters
+    ----------
+    num_cpus:
+        number of worker processes for the new pool.
+
+    Returns
+    -------
+    A freshly started pathos or multiprocessing pool, selected by
+    ``settings.MULTIPROC``.
+    """
+    with _capped_blas_threads():
+        if settings.MULTIPROC == "pathos":
+            try:
+                import dill
+                import pathos
+            except ImportError:
+                raise ImportError(
+                    "scqubits multiprocessing mode set to 'pathos'. Need but cannot"
+                    " find 'pathos'/'dill'!"
+                )
+            dill.settings["recurse"] = True
+            return pathos.pools.ProcessPool(nodes=num_cpus)
+        if settings.MULTIPROC == "multiprocessing":
+            import multiprocessing
+
+            return multiprocessing.Pool(processes=num_cpus)
     raise ValueError(
         "Unknown multiprocessing type: settings.MULTIPROC = {}".format(
             settings.MULTIPROC
         )
     )
+
+
+@atexit.register
+def _shutdown_cached_pool() -> None:
+    """Shut down the worker pool cached in ``settings.POOL`` at interpreter exit.
+
+    Without this, the reused pool's worker processes outlive the interpreter and
+    are only reaped by the operating system.
+    """
+    pool = settings.POOL
+    if pool is not None:
+        _shutdown_pool(pool)
+        settings.POOL = None

--- a/tools/autotune_multiprocessing.py
+++ b/tools/autotune_multiprocessing.py
@@ -61,7 +61,6 @@ for _p in (_REPO_ROOT, _TOOLS_DIR):
 
 import benchmark_multiprocessing as bench  # system builders + pool cleanup
 
-
 _BLAS_ENV_VARS = (
     "OPENBLAS_NUM_THREADS",
     "MKL_NUM_THREADS",
@@ -95,8 +94,12 @@ def _stats(times: list[float]) -> dict[str, float]:
     }
 
 
-def _timed(make_and_run: Callable[[], Any], min_repeats: int, max_repeats: int,
-           cv_target: float) -> dict[str, float]:
+def _timed(
+    make_and_run: Callable[[], Any],
+    min_repeats: int,
+    max_repeats: int,
+    cv_target: float,
+) -> dict[str, float]:
     """Warm up once, then repeat until CV < cv_target (>= min_repeats) or max_repeats."""
     bench._cleanup_pool()
     make_and_run()  # warm-up: pays first-spawn / import cost, discarded
@@ -107,7 +110,8 @@ def _timed(make_and_run: Callable[[], Any], min_repeats: int, max_repeats: int,
         start = time.perf_counter()
         make_and_run()
         times.append(time.perf_counter() - start)
-        if len(times) >= min_repeats:
+        # CV needs >= 2 samples; never early-stop on a single data point.
+        if len(times) >= max(2, min_repeats):
             mean = statistics.fmean(times)
             cv = (statistics.stdev(times) / mean) if mean else 0.0
             if cv < cv_target:
@@ -123,7 +127,9 @@ def _parse_int_list(raw: str, cores: int) -> list[int]:
     return sorted({min(int(tok), cores) for tok in raw.split(",") if tok.strip()})
 
 
-def _build_configs(num_cpus_list: list[int], blas_spec: str, cores: int) -> list[tuple[int, int]]:
+def _build_configs(
+    num_cpus_list: list[int], blas_spec: str, cores: int
+) -> list[tuple[int, int]]:
     """Return (num_cpus, blas_threads) configs, pruned to product <= cores.
 
     ``blas_spec`` is a comma list of ints and/or the token ``auto`` (=
@@ -168,25 +174,35 @@ def _measure_in_process(args: argparse.Namespace, num_cpus: int) -> dict[str, fl
     return _timed(make_and_run, args.min_repeats, args.max_repeats, args.cv_target)
 
 
-def _run_config_isolated(args: argparse.Namespace, num_cpus: int, blas: int) -> dict[str, Any]:
+def _run_config_isolated(
+    args: argparse.Namespace, num_cpus: int, blas: int
+) -> dict[str, Any]:
     """Launch a fresh subprocess with BLAS threads preset; return its stats."""
     env = dict(os.environ)
     for var in _BLAS_ENV_VARS:
         env[var] = str(blas)
     cmd = [
-        sys.executable, os.path.abspath(__file__),
-        "--measure", str(num_cpus),
-        "--profile", args.profile,
-        "--grid", str(args.grid),
-        "--evals-count", str(args.evals_count),
-        "--min-repeats", str(args.min_repeats),
-        "--max-repeats", str(args.max_repeats),
-        "--cv-target", str(args.cv_target),
+        sys.executable,
+        os.path.abspath(__file__),
+        "--measure",
+        str(num_cpus),
+        "--profile",
+        args.profile,
+        "--grid",
+        str(args.grid),
+        "--evals-count",
+        str(args.evals_count),
+        "--min-repeats",
+        str(args.min_repeats),
+        "--max-repeats",
+        str(args.max_repeats),
+        "--cv-target",
+        str(args.cv_target),
     ]
     proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
     for line in proc.stdout.splitlines():
         if line.startswith("__RESULT__"):
-            return json.loads(line[len("__RESULT__"):])
+            return json.loads(line[len("__RESULT__") :])
     raise RuntimeError(
         f"measurement failed for num_cpus={num_cpus} blas={blas} (exit {proc.returncode}).\n"
         f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
@@ -199,6 +215,7 @@ def _run_config_isolated(args: argparse.Namespace, num_cpus: int, blas: int) -> 
 def _blas_backend() -> str:
     try:
         from threadpoolctl import threadpool_info
+
         pools = threadpool_info()
         if pools:
             return ", ".join(
@@ -212,6 +229,7 @@ def _blas_backend() -> str:
 def _start_method() -> str:
     try:
         import multiprocessing
+
         return multiprocessing.get_start_method(allow_none=True) or "default"
     except Exception:
         return "unknown"
@@ -247,19 +265,32 @@ def main(argv: list[str] | None = None) -> int:
         description="Auto-tune num_cpus x BLAS-threads for scqubits sweeps."
     )
     parser.add_argument("--profile", default="heavy", choices=["light", "heavy"])
-    parser.add_argument("--grid", type=int, default=24, help="flux points (ng axis = 3)")
+    parser.add_argument(
+        "--grid", type=int, default=24, help="flux points (ng axis = 3)"
+    )
     parser.add_argument("--evals-count", type=int, default=20)
-    parser.add_argument("--num-cpus", default=None,
-                        help="comma list (default: 1,2,4,8,... up to cpu_count)")
-    parser.add_argument("--blas", default="1,auto",
-                        help="comma list of BLAS threads/worker and/or 'auto' (=cores//num_cpus)")
+    parser.add_argument(
+        "--num-cpus",
+        default=None,
+        help="comma list (default: 1,2,4,8,... up to cpu_count)",
+    )
+    parser.add_argument(
+        "--blas",
+        default="1,auto",
+        help="comma list of BLAS threads/worker and/or 'auto' (=cores//num_cpus)",
+    )
     parser.add_argument("--min-repeats", type=int, default=3)
     parser.add_argument("--max-repeats", type=int, default=8)
-    parser.add_argument("--cv-target", type=float, default=0.05,
-                        help="stop repeating a config once CV drops below this")
+    parser.add_argument(
+        "--cv-target",
+        type=float,
+        default=0.05,
+        help="stop repeating a config once CV drops below this",
+    )
     parser.add_argument("--json", nargs="?", const="<auto>", default=None)
-    parser.add_argument("--measure", type=int, default=None,
-                        help=argparse.SUPPRESS)  # internal: one config in a preset env
+    parser.add_argument(
+        "--measure", type=int, default=None, help=argparse.SUPPRESS
+    )  # internal: one config in a preset env
     args = parser.parse_args(argv)
 
     # Internal worker: BLAS env was preset by the launcher; time one config.
@@ -276,11 +307,15 @@ def main(argv: list[str] | None = None) -> int:
     configs = _build_configs(num_cpus_list, args.blas, cores)
 
     meta = _env_metadata(args, cores)
-    print(f"autotune: {meta['platform']}  cores={cores}  BLAS={meta['blas_backend']}  "
-          f"start_method={meta['start_method']}  scqubits={meta['scqubits_version']}")
-    print(f"profile={args.profile}  grid={args.grid} ({args.grid * 3} pts)  "
-          f"evals_count={args.evals_count}  cv_target={args.cv_target}  "
-          f"repeats={args.min_repeats}-{args.max_repeats}")
+    print(
+        f"autotune: {meta['platform']}  cores={cores}  BLAS={meta['blas_backend']}  "
+        f"start_method={meta['start_method']}  scqubits={meta['scqubits_version']}"
+    )
+    print(
+        f"profile={args.profile}  grid={args.grid} ({args.grid * 3} pts)  "
+        f"evals_count={args.evals_count}  cv_target={args.cv_target}  "
+        f"repeats={args.min_repeats}-{args.max_repeats}"
+    )
     print(f"searching {len(configs)} configs (num_cpus x BLAS, product <= {cores}):")
 
     results: list[dict[str, Any]] = []
@@ -289,34 +324,67 @@ def main(argv: list[str] | None = None) -> int:
         row = {"num_cpus": num_cpus, "blas_threads": blas, **stats}
         results.append(row)
         warn = "  [!] noisy" if stats["cv"] >= 0.10 else ""
-        print(f"  num_cpus={num_cpus:>3}  blas={blas:>3}  "
-              f"median={stats['median_s']:7.3f}s  min={stats['min_s']:7.3f}s  "
-              f"cv={stats['cv']:.1%}  n={stats['n_used']}{warn}")
+        print(
+            f"  num_cpus={num_cpus:>3}  blas={blas:>3}  "
+            f"median={stats['median_s']:7.3f}s  min={stats['min_s']:7.3f}s  "
+            f"cv={stats['cv']:.1%}  n={stats['n_used']}{warn}"
+        )
 
     # Default a user gets out of the box: num_cpus=1, BLAS uncapped (= cores).
+    # If that config is not in the search set, leave speedup-vs-default undefined
+    # rather than comparing against the slowest measured config (which would
+    # silently inflate the reported speedups).
     default = next(
         (r for r in results if r["num_cpus"] == 1 and r["blas_threads"] == cores), None
     )
-    default_median = default["median_s"] if default else max(r["median_s"] for r in results)
+    default_median = default["median_s"] if default else None
     for r in results:
-        r["speedup_vs_default"] = default_median / r["median_s"]
+        r["speedup_vs_default"] = (
+            default_median / r["median_s"] if default_median is not None else None
+        )
 
     best = min(results, key=lambda r: r["median_s"])
     print("\n=== recommendation (this machine + workload only) ===")
-    print(f"  num_cpus={best['num_cpus']}, BLAS-threads/worker={best['blas_threads']}  "
-          f"-> {best['median_s']:.3f}s")
-    if default:
-        print(f"  {best['speedup_vs_default']:.2f}x faster than the default "
-              f"(num_cpus=1, BLAS={cores}): {default_median:.3f}s")
-    print(f"  Apply with: scqubits.settings.NUM_CPUS = {best['num_cpus']}  and set "
-          f"OPENBLAS_NUM_THREADS={best['blas_threads']} before importing scqubits.")
+    print(
+        f"  num_cpus={best['num_cpus']}, BLAS-threads/worker={best['blas_threads']}  "
+        f"-> {best['median_s']:.3f}s"
+    )
+    if default is not None:
+        print(
+            f"  {best['speedup_vs_default']:.2f}x faster than the default "
+            f"(num_cpus=1, BLAS={cores}): {default_median:.3f}s"
+        )
+    else:
+        print(
+            f"  [!] baseline config (num_cpus=1, BLAS={cores}) was not in the "
+            "search set; speedup-vs-default not computed. Add '1' to --num-cpus "
+            "and the uncapped BLAS value (or 'auto') to --blas to measure it."
+        )
+    print(
+        f"  Apply with: scqubits.settings.NUM_CPUS = {best['num_cpus']}  and set "
+        f"OPENBLAS_NUM_THREADS={best['blas_threads']} before importing scqubits."
+    )
     if best["cv"] >= 0.10:
-        print("  [!] best config was noisy (CV >= 10%); rerun with higher --max-repeats.")
+        print(
+            "  [!] best config was noisy (CV >= 10%); rerun with higher --max-repeats."
+        )
+    n_used_values = [r["n_used"] for r in results]
+    if n_used_values and max(n_used_values) - min(n_used_values) >= 3:
+        print(
+            f"  [!] configs used {min(n_used_values)}-{max(n_used_values)} repeats; "
+            "faster configs stop earlier (fewer samples), which can bias close "
+            "rankings. Raise --min-repeats to sample all configs more evenly."
+        )
 
     if args.json is not None:
-        report = {"meta": meta, "configs": results,
-                  "recommendation": {k: best[k] for k in
-                                     ("num_cpus", "blas_threads", "median_s", "speedup_vs_default")}}
+        report = {
+            "meta": meta,
+            "configs": results,
+            "recommendation": {
+                k: best[k]
+                for k in ("num_cpus", "blas_threads", "median_s", "speedup_vs_default")
+            },
+        }
         results_dir = os.path.join(_TOOLS_DIR, "benchmark_results")
         os.makedirs(results_dir, exist_ok=True)
         if args.json == "<auto>":

--- a/tools/benchmark_multiprocessing.py
+++ b/tools/benchmark_multiprocessing.py
@@ -71,16 +71,31 @@ import scqubits.core.qubit_base as qubit_base
 import scqubits.settings as settings
 import scqubits.utils.cpu_switch as cpu_switch
 
-
 # Reference eigenvalues for sweep["evals"][1, 1] with the "light" system below
 # and evals_count=20. Copied from scqubits/tests/test_parametersweep.py so the
 # benchmarked computation can be sanity-checked for correctness.
 _REFERENCE_EVALS_11 = np.array(
     [
-        -38.24067872, -34.80636811, -33.70287551, -31.50027076, -31.23467726,
-        -30.28547786, -29.16544659, -27.80039104, -27.08317259, -26.69778263,
-        -25.76389721, -24.59864846, -24.49435409, -24.43639473, -23.2803766,
-        -22.63621727, -22.16084701, -21.00224623, -21.00053542, -20.07811164,
+        -38.24067872,
+        -34.80636811,
+        -33.70287551,
+        -31.50027076,
+        -31.23467726,
+        -30.28547786,
+        -29.16544659,
+        -27.80039104,
+        -27.08317259,
+        -26.69778263,
+        -25.76389721,
+        -24.59864846,
+        -24.49435409,
+        -24.43639473,
+        -23.2803766,
+        -22.63621727,
+        -22.16084701,
+        -21.00224623,
+        -21.00053542,
+        -20.07811164,
     ]
 )
 
@@ -103,12 +118,22 @@ def _build_components() -> tuple[Any, Any, Any]:
     """Return the two tunable transmons and the oscillator for the active profile."""
     p = PROFILES[PROFILE]
     tmon1 = scq.TunableTransmon(
-        EJmax=40.0, EC=0.2, d=0.1, flux=0.0, ng=0.3,
-        ncut=p["ncut1"], truncated_dim=p["dim1"],
+        EJmax=40.0,
+        EC=0.2,
+        d=0.1,
+        flux=0.0,
+        ng=0.3,
+        ncut=p["ncut1"],
+        truncated_dim=p["dim1"],
     )
     tmon2 = scq.TunableTransmon(
-        EJmax=15.0, EC=0.15, d=0.2, flux=0.0, ng=0.0,
-        ncut=p["ncut2"], truncated_dim=p["dim2"],
+        EJmax=15.0,
+        EC=0.15,
+        d=0.2,
+        flux=0.0,
+        ng=0.0,
+        ncut=p["ncut2"],
+        truncated_dim=p["dim2"],
     )
     resonator = scq.Oscillator(E_osc=4.5, truncated_dim=p["res_dim"])
     return tmon1, tmon2, resonator
@@ -118,10 +143,16 @@ def _build_hilbertspace(tmon1: Any, tmon2: Any, resonator: Any) -> Any:
     """Assemble the coupled HilbertSpace used throughout the benchmark."""
     hilbertspace = scq.HilbertSpace([tmon1, tmon2, resonator])
     hilbertspace.add_interaction(
-        g_strength=0.1, op1=tmon1.n_operator, op2=resonator.creation_operator, add_hc=True
+        g_strength=0.1,
+        op1=tmon1.n_operator,
+        op2=resonator.creation_operator,
+        add_hc=True,
     )
     hilbertspace.add_interaction(
-        g_strength=0.2, op1=tmon2.n_operator, op2=resonator.creation_operator, add_hc=True
+        g_strength=0.2,
+        op1=tmon2.n_operator,
+        op2=resonator.creation_operator,
+        add_hc=True,
     )
     return hilbertspace
 
@@ -266,50 +297,67 @@ def _time_callable(
     }
 
 
-def _run_isolated(scenario: str, num_cpus: int, args: argparse.Namespace) -> dict[str, Any]:
+def _run_isolated(
+    scenario: str, num_cpus: int, args: argparse.Namespace
+) -> dict[str, Any]:
     """Measure one config in a fresh subprocess (no leftover-pool contamination)."""
     cmd = [
-        sys.executable, os.path.abspath(__file__),
-        "--single", scenario, str(num_cpus),
-        "--profile", PROFILE,
-        "--grid", str(args.grid),
-        "--repeats", str(args.repeats),
-        "--evals-count", str(args.evals_count),
+        sys.executable,
+        os.path.abspath(__file__),
+        "--single",
+        scenario,
+        str(num_cpus),
+        "--profile",
+        PROFILE,
+        "--grid",
+        str(args.grid),
+        "--repeats",
+        str(args.repeats),
+        "--evals-count",
+        str(args.evals_count),
     ]
     if args.blas_threads is not None:
         cmd += ["--blas-threads", str(args.blas_threads)]
     proc = subprocess.run(cmd, capture_output=True, text=True)
     for line in proc.stdout.splitlines():
         if line.startswith("__RESULT__"):
-            return json.loads(line[len("__RESULT__"):])
+            return json.loads(line[len("__RESULT__") :])
     raise RuntimeError(
         f"isolated run failed for {scenario}/{num_cpus} (exit {proc.returncode}).\n"
         f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
     )
 
 
-def _runner_for(scenario: str, args: argparse.Namespace, num_cpus: int) -> Callable[[], Any]:
+def _runner_for(
+    scenario: str, args: argparse.Namespace, num_cpus: int
+) -> Callable[[], Any]:
     """Return a zero-arg callable that builds + runs one scenario at `num_cpus`."""
     if scenario == "sweep":
+
         def run() -> Any:
             sweep = _build_sweep(args.grid, args.evals_count, num_cpus)
             sweep.run()
             return sweep
+
         return run
     if scenario == "hspace":
+
         def run() -> Any:
             hspace, flux_vals, update = _build_hspace_scan(args.grid)
             return hspace.get_spectrum_vs_paramvals(
                 flux_vals, update, evals_count=args.evals_count, num_cpus=num_cpus
             )
+
         return run
     if scenario == "qubit":
+
         def run() -> Any:
             tmon, _, _ = _build_components()
             flux_vals = np.linspace(0.0, 2.0, max(args.grid, 50))
             return tmon.get_spectrum_vs_paramvals(
                 "flux", flux_vals, evals_count=args.evals_count, num_cpus=num_cpus
             )
+
         return run
     raise ValueError(f"unknown scenario: {scenario}")
 
@@ -361,8 +409,10 @@ def _verify(num_cpus: int) -> bool:
     finally:
         PROFILE = saved_profile
     ok = bool(np.allclose(_REFERENCE_EVALS_11, calculated))
-    print(f"[verify] sweep evals[1,1] vs reference (num_cpus={num_cpus}): "
-          f"{'PASS' if ok else 'FAIL'}")
+    print(
+        f"[verify] sweep evals[1,1] vs reference (num_cpus={num_cpus}): "
+        f"{'PASS' if ok else 'FAIL'}"
+    )
     return ok
 
 
@@ -403,29 +453,61 @@ def main(argv: list[str] | None = None) -> int:
     global PROFILE
 
     parser = argparse.ArgumentParser(description="scqubits multiprocessing benchmark.")
-    parser.add_argument("--scenario", default="all",
-                        choices=["sweep", "hspace", "qubit", "all"])
-    parser.add_argument("--profile", default="light", choices=["light", "heavy"],
-                        help="workload size (heavy => MP can pay off)")
-    parser.add_argument("--num-cpus", default="1,2,4",
-                        help="comma-separated worker counts, e.g. '1,2,4'")
-    parser.add_argument("--grid", type=int, default=11,
-                        help="number of flux points (ng axis fixed at 3 for sweep)")
+    parser.add_argument(
+        "--scenario", default="all", choices=["sweep", "hspace", "qubit", "all"]
+    )
+    parser.add_argument(
+        "--profile",
+        default="light",
+        choices=["light", "heavy"],
+        help="workload size (heavy => MP can pay off)",
+    )
+    parser.add_argument(
+        "--num-cpus",
+        default="1,2,4",
+        help="comma-separated worker counts, e.g. '1,2,4'",
+    )
+    parser.add_argument(
+        "--grid",
+        type=int,
+        default=11,
+        help="number of flux points (ng axis fixed at 3 for sweep)",
+    )
     parser.add_argument("--repeats", type=int, default=5)
     parser.add_argument("--evals-count", type=int, default=20)
-    parser.add_argument("--verify", action="store_true",
-                        help="run the light 11x3 correctness guard against reference evals")
-    parser.add_argument("--json", nargs="?", const="<auto>", default=None,
-                        help="write results JSON (optional path; default under "
-                             "tools/benchmark_results/)")
-    parser.add_argument("--isolate", action="store_true",
-                        help="run each (scenario, num_cpus) in a fresh subprocess "
-                             "for contamination-free wall times")
-    parser.add_argument("--blas-threads", type=int, default=None,
-                        help="cap BLAS/OpenMP threads per worker via "
-                             "settings.MULTIPROC_BLAS_THREADS during num_cpus>1 runs")
-    parser.add_argument("--single", nargs=2, default=None,
-                        metavar=("SCENARIO", "NUMCPUS"), help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="run the light 11x3 correctness guard against reference evals",
+    )
+    parser.add_argument(
+        "--json",
+        nargs="?",
+        const="<auto>",
+        default=None,
+        help="write results JSON (optional path; default under "
+        "tools/benchmark_results/)",
+    )
+    parser.add_argument(
+        "--isolate",
+        action="store_true",
+        help="run each (scenario, num_cpus) in a fresh subprocess "
+        "for contamination-free wall times",
+    )
+    parser.add_argument(
+        "--blas-threads",
+        type=int,
+        default=None,
+        help="cap BLAS/OpenMP threads per worker via "
+        "settings.MULTIPROC_BLAS_THREADS during num_cpus>1 runs",
+    )
+    parser.add_argument(
+        "--single",
+        nargs=2,
+        default=None,
+        metavar=("SCENARIO", "NUMCPUS"),
+        help=argparse.SUPPRESS,
+    )
     args = parser.parse_args(argv)
 
     PROFILE = args.profile
@@ -435,6 +517,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         import dill  # noqa: F401
         import pathos  # noqa: F401
+
         backend_available = True
     except ImportError:
         backend_available = False
@@ -450,19 +533,27 @@ def main(argv: list[str] | None = None) -> int:
         single_scenario, single_cpus = args.single[0], int(args.single[1])
         with _MapInstrument() as instrument:
             timing = _time_callable(
-                _runner_for(single_scenario, args, single_cpus), args.repeats, instrument
+                _runner_for(single_scenario, args, single_cpus),
+                args.repeats,
+                instrument,
             )
         print("__RESULT__" + json.dumps(timing))
         return 0
 
     num_cpus_list = _parse_num_cpus(args.num_cpus, backend_available)
-    scenarios = ["sweep", "hspace", "qubit"] if args.scenario == "all" else [args.scenario]
+    scenarios = (
+        ["sweep", "hspace", "qubit"] if args.scenario == "all" else [args.scenario]
+    )
 
-    print(f"platform={platform.platform()}  cpu_count={os.cpu_count()}  "
-          f"MULTIPROC={settings.MULTIPROC}  scqubits={scq.__version__}")
-    print(f"profile={PROFILE}  num_cpus={num_cpus_list}  grid={args.grid}  "
-          f"repeats={args.repeats}  evals_count={args.evals_count}  "
-          f"blas_threads_per_worker={settings.MULTIPROC_BLAS_THREADS}")
+    print(
+        f"platform={platform.platform()}  cpu_count={os.cpu_count()}  "
+        f"MULTIPROC={settings.MULTIPROC}  scqubits={scq.__version__}"
+    )
+    print(
+        f"profile={PROFILE}  num_cpus={num_cpus_list}  grid={args.grid}  "
+        f"repeats={args.repeats}  evals_count={args.evals_count}  "
+        f"blas_threads_per_worker={settings.MULTIPROC_BLAS_THREADS}"
+    )
 
     if args.verify:
         _verify(num_cpus=1)
@@ -486,7 +577,9 @@ def main(argv: list[str] | None = None) -> int:
                     "scenario": scenario,
                     "profile": PROFILE,
                     "num_cpus": num_cpus,
-                    "grid_points": args.grid * 3 if scenario == "sweep" else max(args.grid, 50),
+                    "grid_points": (
+                        args.grid * 3 if scenario == "sweep" else max(args.grid, 50)
+                    ),
                     "evals_count": args.evals_count,
                     "repeats": args.repeats,
                     "speedup_vs_1": speedup,
@@ -500,8 +593,10 @@ def main(argv: list[str] | None = None) -> int:
     serialization = _measure_serialization(args)
     print("\n=== serialization payload (dill) ===")
     if serialization.get("available"):
-        print(f"HilbertSpace: {serialization['hilbertspace_bytes']:,} bytes  "
-              f"(dumps {serialization['hilbertspace_dumps_s'] * 1e3:.1f} ms)")
+        print(
+            f"HilbertSpace: {serialization['hilbertspace_bytes']:,} bytes  "
+            f"(dumps {serialization['hilbertspace_dumps_s'] * 1e3:.1f} ms)"
+        )
         print(f"update closure: {serialization['update_func_bytes']:,} bytes")
     else:
         print("dill unavailable; skipped.")


### PR DESCRIPTION
Follow-up to `perf/multiprocessing` addressing a multi-agent review of the pool-reuse / BLAS-cap / per-point-IPC changes. Targets `perf/multiprocessing` so it reviews as the delta; retarget to `main` if you prefer one combined PR.

## What's here (4 commits)
1. **Restore parent BLAS env, clean up pools, validate thread cap** — the cap no longer permanently mutates the parent `os.environ` (snapshot/restore around pool creation); an `atexit` handler shuts down the cached `settings.POOL`; `_shutdown_pool` logs cleanup failures instead of swallowing them; `MULTIPROC_BLAS_THREADS` is validated (positive int or None) and typed `Optional[int]`.
2. **Make the BLAS cap effective on fork via threadpoolctl** — the env-var-only cap was **inert** for fork-based workers (the pathos default on Linux/macOS) and Apple Accelerate. When `threadpoolctl` is installed, the parent's BLAS thread count is now limited for the duration of pool creation so forked workers inherit it; a one-time warning fires when the cap provably can't take effect. `threadpoolctl` is optional (added to the `develop` extra + mypy ignore list).
3. **Document the `self._data` detach contract** in `_dressed_spectrum_sweep` (update_hilbertspace callbacks must not read the temporarily-detached bare-esys entries).
4. **Autotuner fixes** — no longer uses the slowest config as a fake speedup baseline when `(num_cpus=1, BLAS=cores)` is absent (reports `null` + a clear note); warns on uneven repeat counts; fixes a `--min-repeats 1` `StatisticsError` crash.

## Platform verification
Measured on Apple Silicon (numpy→Accelerate, scipy→bundled OpenBLAS, pathos forks, 10 cores):
- Forked worker scipy-OpenBLAS threads drop **10 → 1** under the cap (via the new threadpoolctl path).
- Heavy 72-point isolated autotune: best `num_cpus=8, BLAS=1` = **4.57× vs default** (`num_cpus=1, BLAS=10`).
- Confirms the original `BENCHMARKS.md` Windows result (~3.6× at 72 pts) — but on fork/Accelerate that gain only exists **because of commit 2**; the original env-var cap did nothing there.

## Test plan
- [x] `uv run pytest` — 436 passed, 14 skipped (incl. `--num_cpus 2`)
- [x] New `scqubits/tests/test_cpu_switch.py` (17 tests: validation, env save/restore, cleanup logging)
- [x] `uvx black --check` clean; mypy clean on changed files; docstring-lint clean
- [ ] CI green

Docs for the new setting are in scqubits-doc (separate PR).