### PR TITLE
RFC: automatic sparse diagonalization default for large composite spectra

### DIFF
--- a/scqubits/core/hilbert_space.py
+++ b/scqubits/core/hilbert_space.py
@@ -400,6 +400,39 @@ class InteractionTermStr(dispatch.DispatchClient, serializers.Serializable):
             return hamiltonian + hamiltonian.dag()
 
 
+def _auto_sparse_diag_method(dim: int, evals_count: int, kind: str) -> str | None:
+    """Pick a default diagonalization method based on the problem size.
+
+    Returns the name of a sparse ``diag`` method (scipy ``eigsh``) when only a small
+    fraction of a large spectrum is requested -- the regime where sparse
+    diagonalization is much faster than dense -- and ``None`` to use the dense QuTiP
+    path otherwise. Controlled by ``settings.AUTO_SPARSE_DIAG`` and the
+    ``SPARSE_DIAG_*`` thresholds.
+
+    Parameters
+    ----------
+    dim:
+        dimension of the Hamiltonian to be diagonalized.
+    evals_count:
+        number of eigenvalues/eigenstates requested.
+    kind:
+        ``'evals'`` or ``'esys'``, selecting the eigenvalues-only or
+        eigenvalues-and-eigenvectors method.
+
+    Returns
+    -------
+    A key into :data:`scqubits.core.diag.DIAG_METHODS`, or ``None`` for the dense
+    default.
+    """
+    if (
+        not getattr(settings, "AUTO_SPARSE_DIAG", False)
+        or dim < settings.SPARSE_DIAG_MIN_DIM
+        or evals_count > max(1, int(dim * settings.SPARSE_DIAG_MAX_EVALS_FRAC))
+    ):
+        return None
+    return "{}_scipy_sparse".format(kind)
+
+
 class HilbertSpace(
     spec_lookup.SpectrumLookupMixin, dispatch.DispatchClient, serializers.Serializable
 ):
@@ -875,7 +908,18 @@ class HilbertSpace(
         hamiltonian_mat = self.hamiltonian(bare_esys=bare_esys)  # type: ignore[arg-type]
 
         if not hasattr(self, "evals_method") or self.evals_method is None:
-            evals = hamiltonian_mat.eigenenergies(eigvals=evals_count)
+            auto_method = _auto_sparse_diag_method(
+                hamiltonian_mat.shape[0], evals_count, "evals"
+            )
+            if auto_method is None:
+                evals = hamiltonian_mat.eigenenergies(eigvals=evals_count)
+            else:
+                try:
+                    evals = diag.DIAG_METHODS[auto_method](
+                        hamiltonian_mat, evals_count=evals_count
+                    )
+                except Exception:
+                    evals = hamiltonian_mat.eigenenergies(eigvals=evals_count)
         else:
             diagonalizer = (
                 diag.DIAG_METHODS[self.evals_method]
@@ -919,7 +963,18 @@ class HilbertSpace(
         hamiltonian_mat = self.hamiltonian(bare_esys=bare_esys)  # type: ignore[arg-type]
 
         if not hasattr(self, "esys_method") or self.esys_method is None:
-            evals, evecs = hamiltonian_mat.eigenstates(eigvals=evals_count)
+            auto_method = _auto_sparse_diag_method(
+                hamiltonian_mat.shape[0], evals_count, "esys"
+            )
+            if auto_method is None:
+                evals, evecs = hamiltonian_mat.eigenstates(eigvals=evals_count)
+            else:
+                try:
+                    evals, evecs = diag.DIAG_METHODS[auto_method](
+                        hamiltonian_mat, evals_count=evals_count
+                    )
+                except Exception:
+                    evals, evecs = hamiltonian_mat.eigenstates(eigvals=evals_count)
         else:
             diagonalizer = (
                 diag.DIAG_METHODS[self.esys_method]

--- a/scqubits/core/hilbert_space.py
+++ b/scqubits/core/hilbert_space.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import functools
 import importlib
 import re
+import warnings
 
 from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
@@ -431,6 +432,51 @@ def _auto_sparse_diag_method(dim: int, evals_count: int, kind: str) -> str | Non
     ):
         return None
     return "{}_scipy_sparse".format(kind)
+
+
+def _diagonalize_default(
+    hamiltonian_mat: qt.Qobj,
+    evals_count: int,
+    kind: str,
+    dense_fallback: Callable[[], Any],
+) -> Any:
+    """Diagonalize via the size-based default method, sparse with dense fallback.
+
+    Used by :meth:`HilbertSpace.eigenvals` / :meth:`HilbertSpace.eigensys` when no
+    explicit ``evals_method`` / ``esys_method`` is set. Uses sparse ``eigsh`` when
+    :func:`_auto_sparse_diag_method` selects it, otherwise the dense QuTiP path; on
+    any sparse-solver failure it warns once and falls back to dense.
+
+    Parameters
+    ----------
+    hamiltonian_mat:
+        Hamiltonian to diagonalize.
+    evals_count:
+        number of eigenvalues/eigenstates requested.
+    kind:
+        ``'evals'`` or ``'esys'``.
+    dense_fallback:
+        zero-argument callable returning the dense result (``eigenenergies`` or
+        ``eigenstates`` of ``hamiltonian_mat``).
+
+    Returns
+    -------
+    The eigenvalues (``kind == 'evals'``) or ``(eigenvalues, eigenvectors)``
+    (``kind == 'esys'``).
+    """
+    auto_method = _auto_sparse_diag_method(hamiltonian_mat.shape[0], evals_count, kind)
+    if auto_method is None:
+        return dense_fallback()
+    try:
+        return diag.DIAG_METHODS[auto_method](hamiltonian_mat, evals_count=evals_count)
+    except Exception:
+        warnings.warn(
+            "scqubits: automatic sparse diagonalization failed; falling back to "
+            "dense. Set scqubits.settings.AUTO_SPARSE_DIAG = False to disable "
+            "automatic sparse diagonalization.",
+            RuntimeWarning,
+        )
+        return dense_fallback()
 
 
 class HilbertSpace(
@@ -891,8 +937,12 @@ class HilbertSpace(
     ) -> ndarray:
         """Calculate eigenvalues of the full Hamiltonian.
 
-        Qutip's :meth:`qutip.Qobj.eigenenergies` is used by default, unless
-        :attr:`evals_method` has been set to something other than ``None``.
+        By default (``evals_method`` is ``None``) a size-based heuristic selects the
+        diagonalizer: sparse scipy ``eigsh`` for large Hamiltonians where only a
+        small fraction of the spectrum is requested (see
+        ``settings.AUTO_SPARSE_DIAG``), otherwise QuTiP's dense
+        :meth:`qutip.Qobj.eigenenergies`. Setting :attr:`evals_method` to a method
+        name or callable overrides this choice.
 
         Parameters
         ----------
@@ -902,24 +952,15 @@ class HilbertSpace(
             optional precomputed bare eigensystems for each subsystem, supplied as
             a dict ``{subsys_index: esys}``; speeds up computation when available.
         """
-        # hamiltonian_mat = self.hamiltonian(bare_esys=bare_esys)
-        # return hamiltonian_mat.eigenenergies(eigvals=evals_count)
-
         hamiltonian_mat = self.hamiltonian(bare_esys=bare_esys)  # type: ignore[arg-type]
 
         if not hasattr(self, "evals_method") or self.evals_method is None:
-            auto_method = _auto_sparse_diag_method(
-                hamiltonian_mat.shape[0], evals_count, "evals"
+            evals = _diagonalize_default(
+                hamiltonian_mat,
+                evals_count,
+                "evals",
+                lambda: hamiltonian_mat.eigenenergies(eigvals=evals_count),
             )
-            if auto_method is None:
-                evals = hamiltonian_mat.eigenenergies(eigvals=evals_count)
-            else:
-                try:
-                    evals = diag.DIAG_METHODS[auto_method](
-                        hamiltonian_mat, evals_count=evals_count
-                    )
-                except Exception:
-                    evals = hamiltonian_mat.eigenenergies(eigvals=evals_count)
         else:
             diagonalizer = (
                 diag.DIAG_METHODS[self.evals_method]
@@ -944,8 +985,12 @@ class HilbertSpace(
     ) -> tuple[ndarray, QutipEigenstates]:
         """Calculate eigenvalues and eigenvectors of the full Hamiltonian.
 
-        Qutip's :meth:`qutip.Qobj.eigenstates` is used by default, unless
-        :attr:`esys_method` has been set to something other than ``None``.
+        By default (``esys_method`` is ``None``) a size-based heuristic selects the
+        diagonalizer: sparse scipy ``eigsh`` for large Hamiltonians where only a
+        small fraction of the spectrum is requested (see
+        ``settings.AUTO_SPARSE_DIAG``), otherwise QuTiP's dense
+        :meth:`qutip.Qobj.eigenstates`. Setting :attr:`esys_method` to a method name
+        or callable overrides this choice.
 
         Parameters
         ----------
@@ -958,23 +1003,25 @@ class HilbertSpace(
         Returns
         -------
         eigenvalues and eigenvectors of the full Hamiltonian.
-        """
 
+        Notes
+        -----
+        Eigenvalues and physical observables (matrix elements, lookup energies) are
+        independent of the diagonalizer. Eigenvectors spanning a degenerate
+        eigenspace are, however, only defined up to a basis choice within that
+        space, so the integer dressed-state labels assigned to degenerate states by
+        the overlap-based lookup may depend on the diagonalization method. Reference
+        states by their bare-state labels rather than by hard-coded dressed indices.
+        """
         hamiltonian_mat = self.hamiltonian(bare_esys=bare_esys)  # type: ignore[arg-type]
 
         if not hasattr(self, "esys_method") or self.esys_method is None:
-            auto_method = _auto_sparse_diag_method(
-                hamiltonian_mat.shape[0], evals_count, "esys"
+            evals, evecs = _diagonalize_default(
+                hamiltonian_mat,
+                evals_count,
+                "esys",
+                lambda: hamiltonian_mat.eigenstates(eigvals=evals_count),
             )
-            if auto_method is None:
-                evals, evecs = hamiltonian_mat.eigenstates(eigvals=evals_count)
-            else:
-                try:
-                    evals, evecs = diag.DIAG_METHODS[auto_method](
-                        hamiltonian_mat, evals_count=evals_count
-                    )
-                except Exception:
-                    evals, evecs = hamiltonian_mat.eigenstates(eigvals=evals_count)
         else:
             diagonalizer = (
                 diag.DIAG_METHODS[self.esys_method]

--- a/scqubits/settings.py
+++ b/scqubits/settings.py
@@ -95,6 +95,20 @@ NUM_CPUS = 1
 #           'pathos'
 MULTIPROC = "pathos"
 
+# Automatic sparse diagonalization (prototype) -----------------------------------------
+# When evals_method / esys_method are left at their default (None), use sparse
+# scipy `eigsh` instead of dense QuTiP diagonalization when only a small fraction of a
+# large spectrum is requested -- the regime of dressed spectra of composite
+# HilbertSpaces, where sparse `eigsh` is dramatically faster than dense (and dense may
+# not even fit in memory). Falls back to the dense QuTiP path if the sparse solver
+# raises. Set AUTO_SPARSE_DIAG = False to restore the always-dense default.
+AUTO_SPARSE_DIAG = True
+# Minimum Hilbert-space dimension at which auto sparse diagonalization is considered.
+SPARSE_DIAG_MIN_DIM = 1000
+# Auto sparse is used only when evals_count <= SPARSE_DIAG_MAX_EVALS_FRAC * dim
+# (sparse `eigsh` only pays off when computing few of many eigenstates).
+SPARSE_DIAG_MAX_EVALS_FRAC = 0.1
+
 # Matplotlib options -------------------------------------------------------------------
 # select fonts
 FONT_SELECTED = None


### PR DESCRIPTION
**Draft / RFC for evaluation** — changes a default, so opened as draft.

## What & why
For composite `HilbertSpace` dressed spectra (coupled qubits), the default diagonalization goes through QuTiP **dense** `eigenenergies`/`eigenstates` — diagonalizing the *entire* matrix to obtain ~20 of thousands of states, which doesn't even fit in memory past ~dim 30k. This PR makes the default (when `evals_method`/`esys_method` are `None`) select **sparse scipy `eigsh`** when only a small fraction of a large spectrum is requested, with a dense fallback.

Gated by new settings (set `AUTO_SPARSE_DIAG = False` to restore old behavior):
- `AUTO_SPARSE_DIAG` (default `True`), `SPARSE_DIAG_MIN_DIM` (1000), `SPARSE_DIAG_MAX_EVALS_FRAC` (0.1).

Small systems (dim < 1000) and many-eigenvalue requests stay dense, unchanged.

## Measured (5 coupled fluxonia, Apple Silicon)
| dressed dim | dense | sparse | speedup |
|---|--:|--:|--:|
| 1024 | 111 ms | 54 ms | 2.1× |
| 3125 | 2.3 s | 0.15 s | **15.7×** |
| 7776 | **38.8 s** | 0.58 s | **67×** |

End-to-end `ParameterSweep` (dim 3125, 16 pts, serial): **47–60 s → 2.5–3.7 s (~17×)**, beating num_cpus=8 by ~10×. The win grows with system size — exactly where it's felt.

## Robustness (verified)
- Spectra identical to **2.3e-13**; `energy_by_bare_index` max |ΔE| = **1.2e-13**; matrix-element operator norms on the lowest-k subspace **identical to 0.00**.
- **Caveat:** integer `dressed_index` labels of *degenerate* states may differ between diagonalizers (the eigenvectors spanning a degenerate eigenspace are basis-arbitrary — inherent, not a solver bug). Documented in `eigensys` Notes + changelog; a true fix would need eigenvector canonicalization within degenerate subspaces (possible follow-up). Reference states by bare labels, not hard-coded dressed indices.

## Tests / checks
- [x] Full suite **419 passed / 14 skipped** (unchanged); test_hilbertspace/parametersweep/spectrumlookup/circuit pass.
- [x] mypy clean on changed files; black + docstring-lint clean.
- [ ] Maintainer decision on (a) flipping the default vs default-off, (b) the degenerate-label canonicalization follow-up.

Docs: scqubits-doc branch `docs/sparse-diag-default` (settings table + changelog).

## Open questions for review
1. Default `AUTO_SPARSE_DIAG` to `True` (ship the win) or `False` (opt-in)?
2. Thresholds (min dim 1000, max frac 0.1) — sensible, or tune?
3. Worth the degenerate-label canonicalization, or is the bare-label-reference guidance enough?