### PR TITLE
Reliable, fast parallel parameter sweeps + live progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ scqubits/.vscode/settings.json
 /docstring_fixer.py
 /modernize_types.py
 /monkeytype.sqlite3
+
+# local, machine-specific benchmark outputs
+/tools/benchmark_results/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,8 @@ module = [
     "matplotlib_inline",
     "matplotlib_inline.*",
     "mpl_toolkits.*",
+    "multiprocess",
+    "multiprocess.*",
     "pathos",
     "pathos.*",
     # Optional acceleration backends imported inside diag.py fallbacks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "scipy>=1.5 ; sys_platform != 'darwin'",
     "scipy>=1.5,<=1.13.1 ; sys_platform == 'darwin'",
     "sympy",
+    "threadpoolctl",
     "tqdm",
 ]
 
@@ -55,7 +56,6 @@ gui = [
 develop = [
     "pytest", "traitlets", "h5py (>=2.10)",
     "mypy", "types-tqdm", "scipy-stubs==1.15.2.2",
-    "threadpoolctl",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ gui = [
 develop = [
     "pytest", "traitlets", "h5py (>=2.10)",
     "mypy", "types-tqdm", "scipy-stubs==1.15.2.2",
+    "threadpoolctl",
 ]
 
 [project.urls]
@@ -106,5 +107,7 @@ module = [
     "qutip.*",
     "sympy",
     "sympy.*",
+    # Optional BLAS-thread limiter used by cpu_switch for fork-based worker caps
+    "threadpoolctl",
 ]
 ignore_missing_imports = true

--- a/scqubits/core/hilbert_space.py
+++ b/scqubits/core/hilbert_space.py
@@ -43,10 +43,7 @@ from scqubits.core.namedslots_array import NamedSlotsNdarray, Parameters
 from scqubits.core.storage import SpectrumData
 from scqubits.io_utils.fileio_qutip import QutipEigenstates
 
-if settings.IN_IPYTHON:
-    from tqdm.notebook import tqdm
-else:
-    from tqdm import tqdm  # type: ignore[assignment]
+from tqdm.auto import tqdm
 
 if TYPE_CHECKING:
     from scqubits.io_utils.fileio import IOData
@@ -1190,28 +1187,25 @@ class HilbertSpace(
             ``settings.NUM_CPUS``).
         """
         num_cpus = num_cpus or settings.NUM_CPUS
-        target_map = cpu_switch.get_map_method(num_cpus)
+        # get_map_method returns a lazy, order-preserving map (built-in map when
+        # serial, pool.imap when parallel); wrapping its output in tqdm gives a live
+        # progress bar that advances as each grid point completes.
+        target_map = cpu_switch.get_map_method(num_cpus, total=len(param_vals))
         if get_eigenstates:
             func = functools.partial(
                 self._esys_for_paramval,
                 update_hilbertspace=update_hilbertspace,
                 evals_count=evals_count,
             )
-            with utils.InfoBar(
-                "Parallel computation of eigenvalues [num_cpus={}]".format(num_cpus),
-                num_cpus,
-            ):
-                eigensystem_mapdata = list(
-                    target_map(
-                        func,
-                        tqdm(
-                            param_vals,
-                            desc="Spectral data",
-                            leave=False,
-                            disable=(num_cpus > 1) or settings.PROGRESSBAR_DISABLED,
-                        ),
-                    )
+            eigensystem_mapdata = list(
+                tqdm(
+                    target_map(func, param_vals),
+                    total=len(param_vals),
+                    desc="Spectral data",
+                    leave=False,
+                    disable=settings.PROGRESSBAR_DISABLED,
                 )
+            )
             eigenvalue_table, eigenstate_table = spec_utils.recast_esys_mapdata(
                 eigensystem_mapdata
             )
@@ -1221,23 +1215,17 @@ class HilbertSpace(
                 update_hilbertspace=update_hilbertspace,
                 evals_count=evals_count,
             )
-            with utils.InfoBar(
-                "Parallel computation of eigensystems [num_cpus={}]".format(num_cpus),
-                num_cpus,
-            ):
-                eigenvalue_table = np.asarray(
-                    list(
-                        target_map(
-                            func,
-                            tqdm(
-                                param_vals,
-                                desc="Spectral data",
-                                leave=False,
-                                disable=(num_cpus > 1) or settings.PROGRESSBAR_DISABLED,
-                            ),
-                        )
+            eigenvalue_table = np.asarray(
+                list(
+                    tqdm(
+                        target_map(func, param_vals),
+                        total=len(param_vals),
+                        desc="Spectral data",
+                        leave=False,
+                        disable=settings.PROGRESSBAR_DISABLED,
                     )
                 )
+            )
             eigenstate_table = None
 
         return storage.SpectrumData(

--- a/scqubits/core/param_sweep.py
+++ b/scqubits/core/param_sweep.py
@@ -1599,13 +1599,18 @@ class ParameterSweep(
         hilbertspace: HilbertSpace,
         evals_count: int,
         update_func: Callable,
-        paramindex_tuple: tuple[int],
+        work_item: tuple[tuple[int, ...], dict[int, list[ndarray]], dict[int, Any]],
     ) -> ndarray:
         """Update the HilbertSpace and compute dressed eigensystem at one grid point.
 
         Updates the parent :class:`HilbertSpace`, propagates the cached bare
         eigensystem of each subsystem (handling hierarchical-diagonalization
         children and parent updates), and returns the dressed eigensystem.
+
+        The per-point bare eigensystem is supplied through ``work_item`` rather
+        than read from ``self._data`` so that mapping this method over the grid
+        does not pickle the full bare-spectrum arrays of every grid point into
+        each worker task (see :meth:`_dressed_spectrum_sweep`).
 
         Parameters
         ----------
@@ -1616,25 +1621,20 @@ class ParameterSweep(
         update_func:
             callable used to update parameter-dependent attributes for the
             current grid point
-        paramindex_tuple:
-            tuple of integer indices selecting the grid point in the
-            multi-dimensional parameter sweep
+        work_item:
+            ``(paramindex_tuple, bare_esys, circuit_esys_point)`` for the grid
+            point: the integer index tuple, the per-subsystem ``[evals, evecs]``
+            bare eigensystem, and the per-subsystem circuit eigensystem used by
+            hierarchically diagonalized subsystems.
 
         Returns
         -------
         Object array of shape ``(2,)`` whose entries are the dressed
         eigenvalues array and the corresponding eigenvectors array.
         """
+        paramindex_tuple, bare_esys, circuit_esys_point = work_item
         paramval_tuple = self._parameters[paramindex_tuple]
         update_func(self, *paramval_tuple)
-        assert self._data is not None
-        bare_esys: dict[int, list[ndarray]] = {
-            subsys_index: [
-                self._data["bare_evals"][subsys_index][paramindex_tuple],
-                self._data["bare_evecs"][subsys_index][paramindex_tuple],
-            ]
-            for subsys_index, _ in enumerate(self.hilbertspace)
-        }
         # update the lookuptables for subsystems using hierarchical diagonalization
         for subsys_index, subsys in enumerate(hilbertspace.subsystem_list):
             if (
@@ -1642,7 +1642,7 @@ class ParameterSweep(
                 and subsys.hierarchical_diagonalization
             ):
                 subsys.set_bare_eigensys(  # type: ignore[union-attr]
-                    self._data["circuit_esys"][subsys_index][paramindex_tuple]
+                    circuit_esys_point[subsys_index]
                 )
 
             # if the subsys has a parent Circuit/Subsystem module, then update its hilbert_space
@@ -1685,27 +1685,60 @@ class ParameterSweep(
         target_map = cpu_switch.get_map_method(self._num_cpus)
         total_count = int(np.prod(self._parameters.counts))
 
-        with utils.InfoBar(
-            "Parallel compute dressed eigensys [num_cpus={}]".format(self._num_cpus),
-            self._num_cpus,
-        ) as p:
-            spectrum_data = list(
-                tqdm(
-                    target_map(
-                        functools.partial(
-                            self._update_and_compute_dressed_esys,
-                            self._hilbertspace,
-                            self._evals_count,
-                            self._update_hilbertspace,
+        # Ship only the current grid point's bare eigensystem to each worker.
+        # Reading these slices from ``self._data`` inside the worker would pickle
+        # the whole grid's bare-spectrum arrays into every task (O(N^2) IPC), so
+        # detach them here, pass per-point slices through the work items, and
+        # restore ``self._data`` afterwards.
+        bare_evals = self._data["bare_evals"]
+        bare_evecs = self._data["bare_evecs"]
+        circuit_esys = self._data["circuit_esys"]
+        subsys_count = len(self.hilbertspace)
+
+        def _work_items() -> Any:
+            for paramindex_tuple in itertools.product(*self._parameters.ranges):
+                bare_esys = {
+                    subsys_index: [
+                        bare_evals[subsys_index][paramindex_tuple],
+                        bare_evecs[subsys_index][paramindex_tuple],
+                    ]
+                    for subsys_index in range(subsys_count)
+                }
+                circuit_esys_point = {
+                    subsys_index: circuit_esys[subsys_index][paramindex_tuple]
+                    for subsys_index in range(subsys_count)
+                }
+                yield (paramindex_tuple, bare_esys, circuit_esys_point)
+
+        self._data["bare_evals"] = None
+        self._data["bare_evecs"] = None
+        self._data["circuit_esys"] = None
+        try:
+            with utils.InfoBar(
+                "Parallel compute dressed eigensys [num_cpus={}]".format(self._num_cpus),
+                self._num_cpus,
+            ) as p:
+                spectrum_data = list(
+                    tqdm(
+                        target_map(
+                            functools.partial(
+                                self._update_and_compute_dressed_esys,
+                                self._hilbertspace,
+                                self._evals_count,
+                                self._update_hilbertspace,
+                            ),
+                            _work_items(),
                         ),
-                        itertools.product(*self._parameters.ranges),
-                    ),
-                    total=total_count,
-                    desc="Dressed spectrum",
-                    leave=False,
-                    disable=self.tqdm_disabled,
+                        total=total_count,
+                        desc="Dressed spectrum",
+                        leave=False,
+                        disable=self.tqdm_disabled,
+                    )
                 )
-            )
+        finally:
+            self._data["bare_evals"] = bare_evals
+            self._data["bare_evecs"] = bare_evecs
+            self._data["circuit_esys"] = circuit_esys
 
         spectrum_data_ndarray = np.asarray(spectrum_data, dtype=object)
         spectrum_data_ndarray = spectrum_data_ndarray.reshape(

--- a/scqubits/core/param_sweep.py
+++ b/scqubits/core/param_sweep.py
@@ -1365,9 +1365,15 @@ class ParameterSweep(
         """
         bar = tqdm(total=total, desc=desc, leave=False, disable=self.tqdm_disabled)
         results = []
-        for item in mapped:
-            results.append(item)
-            bar.update(1)
+        try:
+            for item in mapped:
+                results.append(item)
+                bar.update(1)
+        except BaseException:
+            # the mapped iterator raised mid-sweep: close this bar so it does not leak
+            # (it was never registered in progress_bars, which only happens on success)
+            bar.close()
+            raise
         if settings.IN_IPYTHON:
             bar.refresh()
             progress_bars.append(bar)
@@ -1439,38 +1445,42 @@ class ParameterSweep(
             self.cause_dispatch()
         settings.DISPATCH_ENABLED = False
 
-        # Phase progress bars (bare, then dressed) are kept open and cleared together
-        # once the dressed sweep finishes; see _consume_with_bar. The list is local
-        # (not on self) because tqdm bars are not picklable and self is shipped to
-        # workers during parallel dispatch.
+        # The outer try restores global state (DISPATCH_ENABLED, the deepcopied
+        # hilbertspace) even if a sweep raises. The inner try closes the phase progress
+        # bars right when the dressed sweep finishes -- the bare bar(s) stay stacked
+        # above the dressed bar until then; see _consume_with_bar. progress_bars is a
+        # local (not on self) because tqdm bars are not picklable and self is shipped
+        # to workers during parallel dispatch.
         progress_bars: list = []
         try:
-            (
-                self._data["bare_evals"],
-                self._data["bare_evecs"],
-                self._data["circuit_esys"],
-            ) = self._bare_spectrum_sweep(progress_bars)
+            try:
+                (
+                    self._data["bare_evals"],
+                    self._data["bare_evecs"],
+                    self._data["circuit_esys"],
+                ) = self._bare_spectrum_sweep(progress_bars)
+                if not self._bare_only:
+                    self._data["evals"], self._data["evecs"] = (
+                        self._dressed_spectrum_sweep(progress_bars)
+                    )
+            finally:
+                for bar in progress_bars:
+                    bar.close()
             if not self._bare_only:
-                self._data["evals"], self._data["evecs"] = self._dressed_spectrum_sweep(
-                    progress_bars
+                self._data["dressed_indices"] = self.generate_lookup(
+                    ordering=self._labeling_scheme,
+                    subsys_priority=self._labeling_subsys_priority,
+                    BEs_count=self._labeling_BEs_count,
                 )
+                (
+                    self._data["lamb"],
+                    self._data["chi"],
+                    self._data["kerr"],
+                ) = self._dispersive_coefficients()
         finally:
-            for bar in progress_bars:
-                bar.close()
-        if not self._bare_only:
-            self._data["dressed_indices"] = self.generate_lookup(
-                ordering=self._labeling_scheme,
-                subsys_priority=self._labeling_subsys_priority,
-                BEs_count=self._labeling_BEs_count,
-            )
-            (
-                self._data["lamb"],
-                self._data["chi"],
-                self._data["kerr"],
-            ) = self._dispersive_coefficients()
-        if self._deepcopy:
-            self._hilbertspace = stored_hilbertspace  # restore original state
-        settings.DISPATCH_ENABLED = True
+            if self._deepcopy:
+                self._hilbertspace = stored_hilbertspace  # restore original state
+            settings.DISPATCH_ENABLED = True
 
     def _bare_spectrum_sweep(
         self, progress_bars: list

--- a/scqubits/core/param_sweep.py
+++ b/scqubits/core/param_sweep.py
@@ -56,10 +56,7 @@ from scqubits.core.storage import SpectrumData
 if TYPE_CHECKING:
     from scqubits.io_utils.fileio import IOData
 
-if settings.IN_IPYTHON:
-    from tqdm.notebook import tqdm
-else:
-    from tqdm import tqdm  # type: ignore[assignment]
+from tqdm.auto import tqdm
 
 from scqubits.utils.typedefs import GIndexTuple, NpIndices
 
@@ -1337,7 +1334,7 @@ class ParameterSweep(
     @property
     def tqdm_disabled(self) -> bool:
         """Return whether the tqdm progress bar should be disabled for this sweep."""
-        return settings.PROGRESSBAR_DISABLED or (self._num_cpus > 1)
+        return settings.PROGRESSBAR_DISABLED
 
     def faulty_interactionterm_suspected(self) -> bool:
         """Check if any interaction terms are specified as fixed matrices."""
@@ -1558,28 +1555,22 @@ class ParameterSweep(
             np.prod([len(param_vals) for param_vals in reduced_parameters])
         )
 
-        target_map = cpu_switch.get_map_method(self._num_cpus)
+        target_map = cpu_switch.get_map_method(self._num_cpus, total=total_count)
 
-        with utils.InfoBar(
-            "Parallel compute bare eigensys for subsystem {} [num_cpus={}]".format(
-                subsystem.id_str, self._num_cpus
-            ),
-            self._num_cpus,
-        ) as p:
-            bare_eigendata_iter: Any = tqdm(
-                target_map(
-                    functools.partial(
-                        self._update_subsys_compute_esys,
-                        self._update_hilbertspace,
-                        subsystem,
-                    ),
-                    itertools.product(*reduced_parameters.paramvals_list),
+        bare_eigendata_iter: Any = tqdm(
+            target_map(
+                functools.partial(
+                    self._update_subsys_compute_esys,
+                    self._update_hilbertspace,
+                    subsystem,
                 ),
-                total=total_count,
-                desc="Bare spectra",
-                leave=False,
-                disable=self.tqdm_disabled,
-            )
+                itertools.product(*reduced_parameters.paramvals_list),
+            ),
+            total=total_count,
+            desc="Bare spectra [{}]".format(subsystem.id_str),
+            leave=False,
+            disable=self.tqdm_disabled,
+        )
 
         bare_eigendata = np.asarray(list(bare_eigendata_iter), dtype=object)
         bare_eigendata = bare_eigendata.reshape((*reduced_parameters.counts, 2))
@@ -1693,8 +1684,8 @@ class ParameterSweep(
         needs as arguments, and the per-point bare eigensystem is delivered to the
         worker through the work item instead.
         """
-        target_map = cpu_switch.get_map_method(self._num_cpus)
         total_count = int(np.prod(self._parameters.counts))
+        target_map = cpu_switch.get_map_method(self._num_cpus, total=total_count)
 
         # Ship only the current grid point's bare eigensystem to each worker.
         # Reading these slices from ``self._data`` inside the worker would pickle
@@ -1727,29 +1718,23 @@ class ParameterSweep(
         self._data["bare_evecs"] = None
         self._data["circuit_esys"] = None
         try:
-            with utils.InfoBar(
-                "Parallel compute dressed eigensys [num_cpus={}]".format(
-                    self._num_cpus
-                ),
-                self._num_cpus,
-            ) as p:
-                spectrum_data = list(
-                    tqdm(
-                        target_map(
-                            functools.partial(
-                                self._update_and_compute_dressed_esys,
-                                self._hilbertspace,
-                                self._evals_count,
-                                self._update_hilbertspace,
-                            ),
-                            _work_items(),
+            spectrum_data = list(
+                tqdm(
+                    target_map(
+                        functools.partial(
+                            self._update_and_compute_dressed_esys,
+                            self._hilbertspace,
+                            self._evals_count,
+                            self._update_hilbertspace,
                         ),
-                        total=total_count,
-                        desc="Dressed spectrum",
-                        leave=False,
-                        disable=self.tqdm_disabled,
-                    )
+                        _work_items(),
+                    ),
+                    total=total_count,
+                    desc="Dressed spectrum",
+                    leave=False,
+                    disable=self.tqdm_disabled,
                 )
+            )
         finally:
             self._data["bare_evals"] = bare_evals
             self._data["bare_evecs"] = bare_evecs

--- a/scqubits/core/param_sweep.py
+++ b/scqubits/core/param_sweep.py
@@ -1681,6 +1681,17 @@ class ParameterSweep(
         Pair of :class:`NamedSlotsNdarray` instances with axes
         ``[<paramname1>, <paramname2>, ...]`` containing dressed eigenvalues
         and dressed eigenvectors, respectively.
+
+        Notes
+        -----
+        While the grid is being mapped, ``self._data["bare_evals"]``,
+        ``self._data["bare_evecs"]`` and ``self._data["circuit_esys"]`` are
+        temporarily set to ``None`` (restored in a ``finally`` block) so that the
+        bound worker callable does not pickle the whole grid's bare spectrum into
+        every task. A user-supplied ``update_hilbertspace`` callback must therefore
+        not read these ``self._data`` entries: it receives the parameter values it
+        needs as arguments, and the per-point bare eigensystem is delivered to the
+        worker through the work item instead.
         """
         target_map = cpu_switch.get_map_method(self._num_cpus)
         total_count = int(np.prod(self._parameters.counts))
@@ -1689,7 +1700,9 @@ class ParameterSweep(
         # Reading these slices from ``self._data`` inside the worker would pickle
         # the whole grid's bare-spectrum arrays into every task (O(N^2) IPC), so
         # detach them here, pass per-point slices through the work items, and
-        # restore ``self._data`` afterwards.
+        # restore ``self._data`` afterwards. While detached, these three entries
+        # are ``None``; a user ``update_hilbertspace`` callback must not read them
+        # (see the Notes in this method's docstring).
         bare_evals = self._data["bare_evals"]
         bare_evecs = self._data["bare_evecs"]
         circuit_esys = self._data["circuit_esys"]
@@ -1715,7 +1728,9 @@ class ParameterSweep(
         self._data["circuit_esys"] = None
         try:
             with utils.InfoBar(
-                "Parallel compute dressed eigensys [num_cpus={}]".format(self._num_cpus),
+                "Parallel compute dressed eigensys [num_cpus={}]".format(
+                    self._num_cpus
+                ),
                 self._num_cpus,
             ) as p:
                 spectrum_data = list(

--- a/scqubits/core/param_sweep.py
+++ b/scqubits/core/param_sweep.py
@@ -1267,6 +1267,7 @@ class ParameterSweep(
         self._ignore_low_overlap = ignore_low_overlap
         self._deepcopy = deepcopy
         self._num_cpus = num_cpus
+        self._progress_bars: list = []
 
         self._out_of_sync = False
         self.reset_preslicing()
@@ -1336,6 +1337,43 @@ class ParameterSweep(
         """Return whether the tqdm progress bar should be disabled for this sweep."""
         return settings.PROGRESSBAR_DISABLED
 
+    def _consume_with_bar(self, mapped: Any, total: int, desc: str) -> list:
+        """Collect the mapped results, driving a tqdm progress bar.
+
+        In Jupyter/IPython the finished bar is kept on screen and registered in
+        ``self._progress_bars``, so the bare-spectrum bar(s) stay visible above the
+        dressed-spectrum bar; all phase bars are then cleared together at the end of
+        :meth:`run` by :meth:`_close_progress_bars`. In a terminal the bar is closed
+        as soon as its phase finishes, preserving the previous sequential display.
+
+        Parameters
+        ----------
+        mapped:
+            iterator of per-grid-point results (the output of the pool ``imap`` or the
+            built-in ``map``), yielded in grid order.
+        total:
+            number of grid points, used for the bar length.
+        desc:
+            progress-bar label for this phase.
+        """
+        bar = tqdm(total=total, desc=desc, leave=False, disable=self.tqdm_disabled)
+        results = []
+        for item in mapped:
+            results.append(item)
+            bar.update(1)
+        if settings.IN_IPYTHON:
+            bar.refresh()
+            self._progress_bars.append(bar)
+        else:
+            bar.close()
+        return results
+
+    def _close_progress_bars(self) -> None:
+        """Clear all deferred phase progress bars together (see :meth:`_consume_with_bar`)."""
+        for bar in self._progress_bars:
+            bar.close()
+        self._progress_bars = []
+
     def faulty_interactionterm_suspected(self) -> bool:
         """Check if any interaction terms are specified as fixed matrices."""
         for interactionterm in self._hilbertspace.interaction_list:
@@ -1400,13 +1438,22 @@ class ParameterSweep(
             self.cause_dispatch()
         settings.DISPATCH_ENABLED = False
 
-        (
-            self._data["bare_evals"],
-            self._data["bare_evecs"],
-            self._data["circuit_esys"],
-        ) = self._bare_spectrum_sweep()
+        # Phase progress bars (bare, then dressed) are kept open and cleared together
+        # once the dressed sweep finishes; see _consume_with_bar / _close_progress_bars.
+        self._progress_bars = []
+        try:
+            (
+                self._data["bare_evals"],
+                self._data["bare_evecs"],
+                self._data["circuit_esys"],
+            ) = self._bare_spectrum_sweep()
+            if not self._bare_only:
+                self._data["evals"], self._data["evecs"] = (
+                    self._dressed_spectrum_sweep()
+                )
+        finally:
+            self._close_progress_bars()
         if not self._bare_only:
-            self._data["evals"], self._data["evecs"] = self._dressed_spectrum_sweep()
             self._data["dressed_indices"] = self.generate_lookup(
                 ordering=self._labeling_scheme,
                 subsys_priority=self._labeling_subsys_priority,
@@ -1557,22 +1604,21 @@ class ParameterSweep(
 
         target_map = cpu_switch.get_map_method(self._num_cpus, total=total_count)
 
-        bare_eigendata_iter: Any = tqdm(
-            target_map(
-                functools.partial(
-                    self._update_subsys_compute_esys,
-                    self._update_hilbertspace,
-                    subsystem,
+        bare_eigendata = np.asarray(
+            self._consume_with_bar(
+                target_map(
+                    functools.partial(
+                        self._update_subsys_compute_esys,
+                        self._update_hilbertspace,
+                        subsystem,
+                    ),
+                    itertools.product(*reduced_parameters.paramvals_list),
                 ),
-                itertools.product(*reduced_parameters.paramvals_list),
+                total_count,
+                "Bare spectra [{}]".format(subsystem.id_str),
             ),
-            total=total_count,
-            desc="Bare spectra [{}]".format(subsystem.id_str),
-            leave=False,
-            disable=self.tqdm_disabled,
+            dtype=object,
         )
-
-        bare_eigendata = np.asarray(list(bare_eigendata_iter), dtype=object)
         bare_eigendata = bare_eigendata.reshape((*reduced_parameters.counts, 2))
 
         # Bare spectral data was only computed once for each parameter that has no
@@ -1718,22 +1764,18 @@ class ParameterSweep(
         self._data["bare_evecs"] = None
         self._data["circuit_esys"] = None
         try:
-            spectrum_data = list(
-                tqdm(
-                    target_map(
-                        functools.partial(
-                            self._update_and_compute_dressed_esys,
-                            self._hilbertspace,
-                            self._evals_count,
-                            self._update_hilbertspace,
-                        ),
-                        _work_items(),
+            spectrum_data = self._consume_with_bar(
+                target_map(
+                    functools.partial(
+                        self._update_and_compute_dressed_esys,
+                        self._hilbertspace,
+                        self._evals_count,
+                        self._update_hilbertspace,
                     ),
-                    total=total_count,
-                    desc="Dressed spectrum",
-                    leave=False,
-                    disable=self.tqdm_disabled,
-                )
+                    _work_items(),
+                ),
+                total_count,
+                "Dressed spectrum",
             )
         finally:
             self._data["bare_evals"] = bare_evals

--- a/scqubits/core/param_sweep.py
+++ b/scqubits/core/param_sweep.py
@@ -1341,11 +1341,13 @@ class ParameterSweep(
     ) -> list:
         """Collect the mapped results, driving a tqdm progress bar.
 
-        In Jupyter/IPython the finished bar is kept on screen and appended to
+        Under IPython (a Jupyter notebook or a terminal IPython shell, i.e.
+        ``settings.IN_IPYTHON``) the finished bar is kept on screen and appended to
         ``progress_bars`` (a list owned by :meth:`run`), so the bare-spectrum bar(s)
         stay visible above the dressed-spectrum bar; :meth:`run` clears them together
-        once the dressed sweep finishes. In a terminal the bar is closed as soon as
-        its phase finishes, preserving the previous sequential display.
+        once the dressed sweep finishes. Otherwise (a plain Python interpreter or
+        script) the bar is closed as soon as its phase finishes, preserving the
+        previous sequential display.
 
         The bars live in a caller-owned list, never on the instance: a ``tqdm`` bar is
         not picklable, and the worker tasks pickle ``self``, so a bar stored on

--- a/scqubits/core/param_sweep.py
+++ b/scqubits/core/param_sweep.py
@@ -1267,7 +1267,6 @@ class ParameterSweep(
         self._ignore_low_overlap = ignore_low_overlap
         self._deepcopy = deepcopy
         self._num_cpus = num_cpus
-        self._progress_bars: list = []
 
         self._out_of_sync = False
         self.reset_preslicing()
@@ -1337,14 +1336,20 @@ class ParameterSweep(
         """Return whether the tqdm progress bar should be disabled for this sweep."""
         return settings.PROGRESSBAR_DISABLED
 
-    def _consume_with_bar(self, mapped: Any, total: int, desc: str) -> list:
+    def _consume_with_bar(
+        self, mapped: Any, total: int, desc: str, progress_bars: list
+    ) -> list:
         """Collect the mapped results, driving a tqdm progress bar.
 
-        In Jupyter/IPython the finished bar is kept on screen and registered in
-        ``self._progress_bars``, so the bare-spectrum bar(s) stay visible above the
-        dressed-spectrum bar; all phase bars are then cleared together at the end of
-        :meth:`run` by :meth:`_close_progress_bars`. In a terminal the bar is closed
-        as soon as its phase finishes, preserving the previous sequential display.
+        In Jupyter/IPython the finished bar is kept on screen and appended to
+        ``progress_bars`` (a list owned by :meth:`run`), so the bare-spectrum bar(s)
+        stay visible above the dressed-spectrum bar; :meth:`run` clears them together
+        once the dressed sweep finishes. In a terminal the bar is closed as soon as
+        its phase finishes, preserving the previous sequential display.
+
+        The bars live in a caller-owned list, never on the instance: a ``tqdm`` bar is
+        not picklable, and the worker tasks pickle ``self``, so a bar stored on
+        ``self`` would break parallel dispatch.
 
         Parameters
         ----------
@@ -1355,6 +1360,8 @@ class ParameterSweep(
             number of grid points, used for the bar length.
         desc:
             progress-bar label for this phase.
+        progress_bars:
+            caller-owned list collecting bars to clear together at the end of the run.
         """
         bar = tqdm(total=total, desc=desc, leave=False, disable=self.tqdm_disabled)
         results = []
@@ -1363,16 +1370,10 @@ class ParameterSweep(
             bar.update(1)
         if settings.IN_IPYTHON:
             bar.refresh()
-            self._progress_bars.append(bar)
+            progress_bars.append(bar)
         else:
             bar.close()
         return results
-
-    def _close_progress_bars(self) -> None:
-        """Clear all deferred phase progress bars together (see :meth:`_consume_with_bar`)."""
-        for bar in self._progress_bars:
-            bar.close()
-        self._progress_bars = []
 
     def faulty_interactionterm_suspected(self) -> bool:
         """Check if any interaction terms are specified as fixed matrices."""
@@ -1439,20 +1440,23 @@ class ParameterSweep(
         settings.DISPATCH_ENABLED = False
 
         # Phase progress bars (bare, then dressed) are kept open and cleared together
-        # once the dressed sweep finishes; see _consume_with_bar / _close_progress_bars.
-        self._progress_bars = []
+        # once the dressed sweep finishes; see _consume_with_bar. The list is local
+        # (not on self) because tqdm bars are not picklable and self is shipped to
+        # workers during parallel dispatch.
+        progress_bars: list = []
         try:
             (
                 self._data["bare_evals"],
                 self._data["bare_evecs"],
                 self._data["circuit_esys"],
-            ) = self._bare_spectrum_sweep()
+            ) = self._bare_spectrum_sweep(progress_bars)
             if not self._bare_only:
-                self._data["evals"], self._data["evecs"] = (
-                    self._dressed_spectrum_sweep()
+                self._data["evals"], self._data["evecs"] = self._dressed_spectrum_sweep(
+                    progress_bars
                 )
         finally:
-            self._close_progress_bars()
+            for bar in progress_bars:
+                bar.close()
         if not self._bare_only:
             self._data["dressed_indices"] = self.generate_lookup(
                 ordering=self._labeling_scheme,
@@ -1469,7 +1473,7 @@ class ParameterSweep(
         settings.DISPATCH_ENABLED = True
 
     def _bare_spectrum_sweep(
-        self,
+        self, progress_bars: list
     ) -> tuple[NamedSlotsNdarray, NamedSlotsNdarray, NamedSlotsNdarray]:
         """Compute bare eigenvalues, eigenvectors, and circuit ``esys`` arrays.
 
@@ -1495,7 +1499,7 @@ class ParameterSweep(
         circuit_esys = np.empty((self.subsystem_count,), dtype=object)
 
         for subsys_index, subsystem in enumerate(self.hilbertspace):
-            bare_esys = self._subsys_bare_spectrum_sweep(subsystem)
+            bare_esys = self._subsys_bare_spectrum_sweep(subsystem, progress_bars)
             if (
                 hasattr(subsystem, "hierarchical_diagonalization")
                 and subsystem.hierarchical_diagonalization
@@ -1583,7 +1587,9 @@ class ParameterSweep(
         ]
         return list(set(self._parameters.names) - set(updating_parameters))
 
-    def _subsys_bare_spectrum_sweep(self, subsystem: QuantumSystem) -> ndarray:
+    def _subsys_bare_spectrum_sweep(
+        self, subsystem: QuantumSystem, progress_bars: list
+    ) -> ndarray:
         """Compute the bare eigensystem of ``subsystem`` over the full parameter grid.
 
         Parameters
@@ -1616,6 +1622,7 @@ class ParameterSweep(
                 ),
                 total_count,
                 "Bare spectra [{}]".format(subsystem.id_str),
+                progress_bars,
             ),
             dtype=object,
         )
@@ -1709,7 +1716,7 @@ class ParameterSweep(
         return esys_array
 
     def _dressed_spectrum_sweep(
-        self,
+        self, progress_bars: list
     ) -> tuple[NamedSlotsNdarray, NamedSlotsNdarray]:
         """Compute dressed eigenvalues and eigenvectors over the full parameter grid.
 
@@ -1776,6 +1783,7 @@ class ParameterSweep(
                 ),
                 total_count,
                 "Dressed spectrum",
+                progress_bars,
             )
         finally:
             self._data["bare_evals"] = bare_evals

--- a/scqubits/core/qubit_base.py
+++ b/scqubits/core/qubit_base.py
@@ -50,9 +50,9 @@ import scqubits.utils.plotting as plot
 from scqubits.core.central_dispatch import DispatchClient
 from scqubits.core.discretization import Grid1d
 from scqubits.core.storage import DataStore, SpectrumData
-from scqubits.settings import IN_IPYTHON, matplotlib_settings
+from scqubits.settings import matplotlib_settings
 from scqubits.utils.cpu_switch import get_map_method
-from scqubits.utils.misc import InfoBar, process_which
+from scqubits.utils.misc import process_which
 from scqubits.utils.spectrum_utils import (
     get_matrixelement_table,
     order_eigensystem,
@@ -60,10 +60,7 @@ from scqubits.utils.spectrum_utils import (
     standardize_sign,
 )
 
-if IN_IPYTHON:
-    from tqdm.notebook import tqdm
-else:
-    from tqdm import tqdm  # type: ignore[assignment]
+from tqdm.auto import tqdm
 
 if TYPE_CHECKING:
     from scqubits.core.storage import WaveFunction
@@ -848,53 +845,45 @@ class QubitBaseClass(QuantumSystem, ABC):
         """
         num_cpus = num_cpus or settings.NUM_CPUS
         previous_paramval = getattr(self, param_name)
-        tqdm_disable = num_cpus > 1 or settings.PROGRESSBAR_DISABLED
+        tqdm_disable = settings.PROGRESSBAR_DISABLED
 
-        target_map = get_map_method(num_cpus)
+        # get_map_method returns a lazy, order-preserving map (built-in map when
+        # serial, pool.imap when parallel), so wrapping its output iterator in tqdm
+        # gives a live progress bar that advances as each grid point completes --
+        # in serial and parallel alike.
+        target_map = get_map_method(num_cpus, total=len(param_vals))
         if not get_eigenstates:
             func_evals = functools.partial(
                 self._evals_for_paramval, param_name=param_name, evals_count=evals_count
             )
-            with InfoBar(
-                "Parallel computation of eigensystems [num_cpus={}]".format(num_cpus),
-                num_cpus,
-            ):
-                eigenvalue_table = np.asarray(
-                    list(
-                        target_map(
-                            func_evals,
-                            tqdm(
-                                param_vals,
-                                desc="Spectral data",
-                                leave=False,
-                                disable=tqdm_disable,
-                            ),
-                        )
+            eigenvalue_table = np.asarray(
+                list(
+                    tqdm(
+                        target_map(func_evals, param_vals),
+                        total=len(param_vals),
+                        desc="Spectral data",
+                        leave=False,
+                        disable=tqdm_disable,
                     )
                 )
+            )
             eigenstate_table = None
         else:
             func_esys = functools.partial(
                 self._esys_for_paramval, param_name=param_name, evals_count=evals_count
             )
-            with InfoBar(
-                "Parallel computation of eigenvalues [num_cpus={}]".format(num_cpus),
-                num_cpus,
-            ):
-                # Note that it is useful here that the outermost eigenstate object is
-                # a list, as for certain applications the necessary hilbert space
-                # dimension can vary with paramvals
-                eigensystem_mapdata = list(
-                    target_map(
-                        func_esys,
-                        tqdm(
-                            param_vals,
-                            desc="Spectral data",
-                            leave=False,
-                            disable=tqdm_disable,
-                        ),
-                    )
+            # Note that it is useful here that the outermost eigenstate object is
+            # a list, as for certain applications the necessary hilbert space
+            # dimension can vary with paramvals
+            eigensystem_mapdata = list(
+                tqdm(
+                    target_map(func_esys, param_vals),
+                    total=len(param_vals),
+                    desc="Spectral data",
+                    leave=False,
+                    disable=tqdm_disable,
                 )
+            )
             eigenvalue_table, eigenstate_table = recast_esys_mapdata(
                 eigensystem_mapdata
             )

--- a/scqubits/settings.py
+++ b/scqubits/settings.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import warnings
 
-from typing import Any, Type
+from typing import Any, Optional, Type
 
 import matplotlib.font_manager as mpl_font
 import numpy as np
@@ -96,13 +96,23 @@ NUM_CPUS = 1
 MULTIPROC = "pathos"
 
 # Cap BLAS/OpenMP threads *per worker process* during parallel sweeps
-# (num_cpus > 1). With the default (None) the environment is left untouched. When
-# many small diagonalizations are swept, the worker processes and the BLAS thread
-# pool otherwise oversubscribe the cores (num_cpus x BLAS-threads >> physical
-# cores); setting this to a small value (e.g. 1, or cores // num_cpus) avoids that.
-# Only affects worker pools created here, and only takes effect for spawn-based
-# workers that re-import numpy (the default on Windows).
-MULTIPROC_BLAS_THREADS: Any = None
+# (num_cpus > 1). Must be a positive int or None; with the default (None) the
+# environment is left untouched. When many small diagonalizations are swept, the
+# worker processes and the BLAS thread pool otherwise oversubscribe the cores
+# (num_cpus x BLAS-threads >> physical cores); setting this to a small value
+# (e.g. 1, or cores // num_cpus) avoids that.
+#
+# IMPORTANT - this only takes effect for SPAWN-based workers whose numpy links
+# against OpenBLAS or MKL. It has no effect when:
+#   - workers are fork-based (the pathos/multiprocessing default on Linux, and on
+#     macOS where the pathos backend forces fork): forked workers inherit the
+#     parent's already-initialized BLAS thread pool and never re-read these vars;
+#   - numpy links against Apple Accelerate (the default on Apple Silicon), which
+#     ignores these environment variables entirely.
+# On those platforms, cap BLAS threads instead by exporting OPENBLAS_NUM_THREADS
+# (etc.) in the shell *before* importing scqubits/numpy. The cap is applied only
+# while the worker pool is created; the parent environment is restored afterwards.
+MULTIPROC_BLAS_THREADS: Optional[int] = None
 
 # Matplotlib options -------------------------------------------------------------------
 # select fonts

--- a/scqubits/settings.py
+++ b/scqubits/settings.py
@@ -95,6 +95,15 @@ NUM_CPUS = 1
 #           'pathos'
 MULTIPROC = "pathos"
 
+# Cap BLAS/OpenMP threads *per worker process* during parallel sweeps
+# (num_cpus > 1). With the default (None) the environment is left untouched. When
+# many small diagonalizations are swept, the worker processes and the BLAS thread
+# pool otherwise oversubscribe the cores (num_cpus x BLAS-threads >> physical
+# cores); setting this to a small value (e.g. 1, or cores // num_cpus) avoids that.
+# Only affects worker pools created here, and only takes effect for spawn-based
+# workers that re-import numpy (the default on Windows).
+MULTIPROC_BLAS_THREADS: Any = None
+
 # Matplotlib options -------------------------------------------------------------------
 # select fonts
 FONT_SELECTED = None

--- a/scqubits/settings.py
+++ b/scqubits/settings.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import warnings
 
-from typing import Any, Optional, Type
+from typing import Any, Type
 
 import matplotlib.font_manager as mpl_font
 import numpy as np
@@ -96,22 +96,27 @@ NUM_CPUS = 1
 MULTIPROC = "pathos"
 
 # Cap BLAS/OpenMP threads *per worker process* during parallel sweeps
-# (num_cpus > 1). Must be a positive int or None; with the default (None) the
-# environment is left untouched. When many small diagonalizations are swept, the
-# worker processes and the BLAS thread pool otherwise oversubscribe the cores
-# (num_cpus x BLAS-threads >> physical cores); setting this to a small value
-# (e.g. 1, or cores // num_cpus) avoids that.
+# (num_cpus > 1). Without a cap, every worker's BLAS spawns as many threads as
+# there are cores, so num_cpus workers oversubscribe the machine
+# (num_cpus x cores threads competing for cores) -- the cause of the large
+# slowdowns on dense workloads. Accepts:
+#   "auto" (default) -- cap each worker to max(1, cores // num_cpus), so the
+#                       workers together use about one thread per core and never
+#                       oversubscribe; the safe choice for parallel sweeps.
+#   a positive int   -- a fixed per-worker cap (e.g. 1 for many small
+#                       diagonalizations).
+#   None             -- leave the environment untouched (opt out, e.g. if you
+#                       tune BLAS threads yourself).
 #
 # The cap reaches workers via the thread-count environment variables, which
 # spawn-based workers (macOS, Windows) re-read when they re-import numpy/scipy.
 # On Linux, where workers are fork-based, the cap relies on 'threadpoolctl'
-# retuning the already-loaded BLAS in the parent before the fork; without it,
-# export OPENBLAS_NUM_THREADS (etc.) in the shell *before* importing scqubits.
-# It has no effect on a BLAS that exposes no thread control (e.g. numpy on Apple
+# retuning the already-loaded BLAS in the parent before the fork. It has no
+# effect on a BLAS that exposes no thread control (e.g. numpy on Apple
 # Accelerate), but scqubits' eigensolvers use scipy's OpenBLAS, which is
 # controllable. The cap is applied only while the worker pool is created; the
 # parent environment is restored afterwards.
-MULTIPROC_BLAS_THREADS: Optional[int] = None
+MULTIPROC_BLAS_THREADS: "int | str | None" = "auto"
 
 # Matplotlib options -------------------------------------------------------------------
 # select fonts

--- a/scqubits/settings.py
+++ b/scqubits/settings.py
@@ -95,6 +95,17 @@ NUM_CPUS = 1
 #           'pathos'
 MULTIPROC = "pathos"
 
+# Process start method for the worker pool.
+# Options:  None (platform default), 'fork', 'spawn', 'forkserver'.
+# The default (None) selects 'fork' on Linux and 'spawn' on macOS and Windows.
+# 'spawn' is used on macOS because fork-after-threads is unsafe with Apple's
+# frameworks (Accelerate/GCD, the Objective-C runtime) and can crash or hang.
+# NOTE: with 'spawn'/'forkserver', worker processes re-import the entry module, so
+# a plain script that triggers parallel computation must guard its entry point with
+# ``if __name__ == "__main__":`` (Jupyter/IPython are unaffected). Set this to
+# 'fork' to restore the previous behavior.
+MULTIPROC_START_METHOD: Optional[str] = None
+
 # Cap BLAS/OpenMP threads *per worker process* during parallel sweeps
 # (num_cpus > 1). Must be a positive int or None; with the default (None) the
 # environment is left untouched. When many small diagonalizations are swept, the

--- a/scqubits/settings.py
+++ b/scqubits/settings.py
@@ -95,17 +95,6 @@ NUM_CPUS = 1
 #           'pathos'
 MULTIPROC = "pathos"
 
-# Process start method for the worker pool.
-# Options:  None (platform default), 'fork', 'spawn', 'forkserver'.
-# The default (None) selects 'fork' on Linux and 'spawn' on macOS and Windows.
-# 'spawn' is used on macOS because fork-after-threads is unsafe with Apple's
-# frameworks (Accelerate/GCD, the Objective-C runtime) and can crash or hang.
-# NOTE: with 'spawn'/'forkserver', worker processes re-import the entry module, so
-# a plain script that triggers parallel computation must guard its entry point with
-# ``if __name__ == "__main__":`` (Jupyter/IPython are unaffected). Set this to
-# 'fork' to restore the previous behavior.
-MULTIPROC_START_METHOD: Optional[str] = None
-
 # Cap BLAS/OpenMP threads *per worker process* during parallel sweeps
 # (num_cpus > 1). Must be a positive int or None; with the default (None) the
 # environment is left untouched. When many small diagonalizations are swept, the
@@ -113,16 +102,15 @@ MULTIPROC_START_METHOD: Optional[str] = None
 # (num_cpus x BLAS-threads >> physical cores); setting this to a small value
 # (e.g. 1, or cores // num_cpus) avoids that.
 #
-# IMPORTANT - this only takes effect for SPAWN-based workers whose numpy links
-# against OpenBLAS or MKL. It has no effect when:
-#   - workers are fork-based (the pathos/multiprocessing default on Linux, and on
-#     macOS where the pathos backend forces fork): forked workers inherit the
-#     parent's already-initialized BLAS thread pool and never re-read these vars;
-#   - numpy links against Apple Accelerate (the default on Apple Silicon), which
-#     ignores these environment variables entirely.
-# On those platforms, cap BLAS threads instead by exporting OPENBLAS_NUM_THREADS
-# (etc.) in the shell *before* importing scqubits/numpy. The cap is applied only
-# while the worker pool is created; the parent environment is restored afterwards.
+# The cap reaches workers via the thread-count environment variables, which
+# spawn-based workers (macOS, Windows) re-read when they re-import numpy/scipy.
+# On Linux, where workers are fork-based, the cap relies on 'threadpoolctl'
+# retuning the already-loaded BLAS in the parent before the fork; without it,
+# export OPENBLAS_NUM_THREADS (etc.) in the shell *before* importing scqubits.
+# It has no effect on a BLAS that exposes no thread control (e.g. numpy on Apple
+# Accelerate), but scqubits' eigensolvers use scipy's OpenBLAS, which is
+# controllable. The cap is applied only while the worker pool is created; the
+# parent environment is restored afterwards.
 MULTIPROC_BLAS_THREADS: Optional[int] = None
 
 # Matplotlib options -------------------------------------------------------------------

--- a/scqubits/tests/test_cpu_switch.py
+++ b/scqubits/tests/test_cpu_switch.py
@@ -159,16 +159,19 @@ class TestImapChunksize:
 
 
 class TestPoolPickleReduction:
-    def test_worker_pools_pickle_to_none(self):
-        # dill recurse can pull settings.POOL into a worker task (e.g. for circuits);
-        # raw multiprocess pools must reduce to None rather than raise on pickle.
-        import pickle
+    # dill recurse can pull settings.POOL into a worker task (e.g. for circuits);
+    # raw multiprocess pools must reduce to None rather than raise on pickle.
+    def test_reduction_reconstructs_none(self):
+        func, args = cpu_switch._pool_reduces_to_none(object())
+        assert func(*args) is None
 
-        cpu_switch._register_pool_pickle_reduction()
+    def test_pool_classes_registered_in_copyreg(self):
+        import copyreg
+
         from multiprocess.pool import Pool as MpPool
 
-        pool = MpPool.__new__(MpPool)  # uninitialized instance, no workers started
-        assert pickle.loads(pickle.dumps(pool)) is None
+        cpu_switch._register_pool_pickle_reduction()
+        assert copyreg.dispatch_table.get(MpPool) is cpu_switch._pool_reduces_to_none
 
 
 class TestResolveStartMethod:
@@ -218,10 +221,21 @@ class TestSpawnGuardWarning:
 class TestPoolReuseSignature:
     def test_reusable_matches_signature(self, monkeypatch):
         monkeypatch.setattr(settings, "MULTIPROC", "pathos")
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", None)
         method = _resolve_start_method()
-        monkeypatch.setattr(cpu_switch, "_pool_signature", ("pathos", method, 4))
+        monkeypatch.setattr(cpu_switch, "_pool_signature", ("pathos", method, 4, None))
         assert cpu_switch._pool_is_reusable(object(), 4) is True
         assert cpu_switch._pool_is_reusable(object(), 2) is False  # different cpu count
+
+    def test_not_reusable_with_different_blas_cap(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC", "pathos")
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", None)
+        method = _resolve_start_method()
+        monkeypatch.setattr(cpu_switch, "_pool_signature", ("pathos", method, 4, 1))
+        # same num_cpus but the cached pool was built with a BLAS cap of 1
+        assert cpu_switch._pool_is_reusable(object(), 4, blas_threads=1) is True
+        assert cpu_switch._pool_is_reusable(object(), 4, blas_threads=2) is False
+        assert cpu_switch._pool_is_reusable(object(), 4) is False  # cap None != 1
 
     def test_not_reusable_when_unset(self, monkeypatch):
         monkeypatch.setattr(cpu_switch, "_pool_signature", None)

--- a/scqubits/tests/test_cpu_switch.py
+++ b/scqubits/tests/test_cpu_switch.py
@@ -85,6 +85,16 @@ class TestEffectiveBlasCap:
         monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", "auto")
         assert _effective_blas_cap(num_cpus=4, blas_threads=3) == 3
 
+    def test_override_bool_rejected(self, monkeypatch):
+        # bool is an int subclass; True must not slip through as 1
+        with pytest.raises(TypeError):
+            _effective_blas_cap(num_cpus=4, blas_threads=True)
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_override_non_positive_rejected(self, monkeypatch, bad):
+        with pytest.raises(ValueError):
+            _effective_blas_cap(num_cpus=4, blas_threads=bad)
+
     def test_auto_cap_helper(self, monkeypatch):
         monkeypatch.setattr(cpu_switch.os, "cpu_count", lambda: 12)
         assert _auto_blas_cap(num_cpus=4) == 3

--- a/scqubits/tests/test_cpu_switch.py
+++ b/scqubits/tests/test_cpu_switch.py
@@ -21,7 +21,9 @@ import scqubits.utils.cpu_switch as cpu_switch
 
 from scqubits.utils.cpu_switch import (
     _BLAS_THREAD_ENV_VARS,
+    _auto_blas_cap,
     _capped_blas_threads,
+    _effective_blas_cap,
     _resolve_start_method,
     _validated_blas_thread_cap,
 )
@@ -32,11 +34,15 @@ class TestValidatedBlasThreadCap:
         monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", None)
         assert _validated_blas_thread_cap() is None
 
+    def test_auto_passes_through(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", "auto")
+        assert _validated_blas_thread_cap() == "auto"
+
     def test_positive_int_passes_through(self, monkeypatch):
         monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 3)
         assert _validated_blas_thread_cap() == 3
 
-    @pytest.mark.parametrize("bad", [1.5, "2", [1], 2.0])
+    @pytest.mark.parametrize("bad", [1.5, "2", "foo", [1], 2.0])
     def test_non_int_rejected(self, monkeypatch, bad):
         monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", bad)
         with pytest.raises(TypeError):
@@ -55,18 +61,45 @@ class TestValidatedBlasThreadCap:
             _validated_blas_thread_cap()
 
 
+class TestEffectiveBlasCap:
+    def test_none_setting_disables_cap(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", None)
+        assert _effective_blas_cap(num_cpus=4, blas_threads=None) is None
+
+    def test_int_setting_used_as_is(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 2)
+        assert _effective_blas_cap(num_cpus=8, blas_threads=None) == 2
+
+    def test_auto_setting_splits_cores_across_workers(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", "auto")
+        monkeypatch.setattr(cpu_switch.os, "cpu_count", lambda: 8)
+        assert _effective_blas_cap(num_cpus=4, blas_threads=None) == 2
+
+    def test_auto_never_drops_below_one(self, monkeypatch):
+        # more workers than cores must still leave each worker at least 1 thread
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", "auto")
+        monkeypatch.setattr(cpu_switch.os, "cpu_count", lambda: 4)
+        assert _effective_blas_cap(num_cpus=16, blas_threads=None) == 1
+
+    def test_override_takes_precedence_over_setting(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", "auto")
+        assert _effective_blas_cap(num_cpus=4, blas_threads=3) == 3
+
+    def test_auto_cap_helper(self, monkeypatch):
+        monkeypatch.setattr(cpu_switch.os, "cpu_count", lambda: 12)
+        assert _auto_blas_cap(num_cpus=4) == 3
+
+
 class TestCappedBlasThreads:
     def test_noop_when_disabled(self, monkeypatch):
-        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", None)
         monkeypatch.delenv("OPENBLAS_NUM_THREADS", raising=False)
-        with _capped_blas_threads():
+        with _capped_blas_threads(None):
             assert "OPENBLAS_NUM_THREADS" not in os.environ
 
     def test_sets_cap_inside_and_removes_after_when_unset_before(self, monkeypatch):
-        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 2)
         for var in _BLAS_THREAD_ENV_VARS:
             monkeypatch.delenv(var, raising=False)
-        with _capped_blas_threads():
+        with _capped_blas_threads(2):
             for var in _BLAS_THREAD_ENV_VARS:
                 assert os.environ[var] == "2"
         # vars that were unset before the block must be removed again
@@ -74,18 +107,16 @@ class TestCappedBlasThreads:
             assert var not in os.environ
 
     def test_restores_preexisting_value(self, monkeypatch):
-        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 1)
         monkeypatch.setenv("OPENBLAS_NUM_THREADS", "7")
-        with _capped_blas_threads():
+        with _capped_blas_threads(1):
             assert os.environ["OPENBLAS_NUM_THREADS"] == "1"
         # a value present before the block must be restored, not deleted
         assert os.environ["OPENBLAS_NUM_THREADS"] == "7"
 
     def test_restores_environment_on_exception(self, monkeypatch):
-        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 1)
         monkeypatch.delenv("OPENBLAS_NUM_THREADS", raising=False)
         with pytest.raises(RuntimeError):
-            with _capped_blas_threads():
+            with _capped_blas_threads(1):
                 raise RuntimeError("boom")
         assert "OPENBLAS_NUM_THREADS" not in os.environ
 

--- a/scqubits/tests/test_cpu_switch.py
+++ b/scqubits/tests/test_cpu_switch.py
@@ -158,6 +158,19 @@ class TestImapChunksize:
         assert mapper("f", "it")[1] == 1
 
 
+class TestPoolPickleReduction:
+    def test_worker_pools_pickle_to_none(self):
+        # dill recurse can pull settings.POOL into a worker task (e.g. for circuits);
+        # raw multiprocess pools must reduce to None rather than raise on pickle.
+        import pickle
+
+        cpu_switch._register_pool_pickle_reduction()
+        from multiprocess.pool import Pool as MpPool
+
+        pool = MpPool.__new__(MpPool)  # uninitialized instance, no workers started
+        assert pickle.loads(pickle.dumps(pool)) is None
+
+
 class TestResolveStartMethod:
     def test_resolves_to_available_method(self):
         assert (

--- a/scqubits/tests/test_cpu_switch.py
+++ b/scqubits/tests/test_cpu_switch.py
@@ -12,6 +12,7 @@
 ############################################################################
 
 import os
+import warnings
 
 import pytest
 
@@ -161,6 +162,32 @@ class TestResolveStartMethod:
         else:
             # macOS / Windows default to spawn (fork-after-threads is unsafe on macOS)
             assert method == "spawn"
+
+
+class TestSpawnGuardWarning:
+    def test_warns_once_under_spawn_non_ipython(self, monkeypatch):
+        monkeypatch.setattr(settings, "IN_IPYTHON", False)
+        monkeypatch.setattr(cpu_switch, "_spawn_guard_warned", False)
+        with pytest.warns(UserWarning, match="__main__"):
+            cpu_switch._warn_spawn_guard("spawn")
+        # second call is a no-op (no warning)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            cpu_switch._warn_spawn_guard("spawn")
+
+    def test_silent_under_ipython(self, monkeypatch):
+        monkeypatch.setattr(settings, "IN_IPYTHON", True)
+        monkeypatch.setattr(cpu_switch, "_spawn_guard_warned", False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            cpu_switch._warn_spawn_guard("spawn")
+
+    def test_silent_under_fork(self, monkeypatch):
+        monkeypatch.setattr(settings, "IN_IPYTHON", False)
+        monkeypatch.setattr(cpu_switch, "_spawn_guard_warned", False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            cpu_switch._warn_spawn_guard("fork")
 
 
 class TestPoolReuseSignature:

--- a/scqubits/tests/test_cpu_switch.py
+++ b/scqubits/tests/test_cpu_switch.py
@@ -140,27 +140,20 @@ class TestGetMapMethodSerial:
 
 
 class TestResolveStartMethod:
-    def test_explicit_override(self, monkeypatch):
-        for method in cpu_switch._backend_module().get_all_start_methods():
-            monkeypatch.setattr(settings, "MULTIPROC_START_METHOD", method)
-            assert _resolve_start_method() == method
-
-    def test_unavailable_override_falls_back(self, monkeypatch):
-        monkeypatch.setattr(settings, "MULTIPROC_START_METHOD", "not-a-method")
+    def test_resolves_to_available_method(self):
         assert (
             _resolve_start_method()
             in cpu_switch._backend_module().get_all_start_methods()
         )
 
-    def test_platform_default(self, monkeypatch):
+    def test_platform_default(self):
         import sys
 
-        monkeypatch.setattr(settings, "MULTIPROC_START_METHOD", None)
         method = _resolve_start_method()
         if sys.platform.startswith("linux"):
             assert method == "fork"
         else:
-            # macOS / Windows default to spawn (fork-after-threads is unsafe on macOS)
+            # macOS / Windows use spawn (fork-after-threads is unsafe on macOS)
             assert method == "spawn"
 
 
@@ -193,7 +186,6 @@ class TestSpawnGuardWarning:
 class TestPoolReuseSignature:
     def test_reusable_matches_signature(self, monkeypatch):
         monkeypatch.setattr(settings, "MULTIPROC", "pathos")
-        monkeypatch.setattr(settings, "MULTIPROC_START_METHOD", None)
         method = _resolve_start_method()
         monkeypatch.setattr(cpu_switch, "_pool_signature", ("pathos", method, 4))
         assert cpu_switch._pool_is_reusable(object(), 4) is True

--- a/scqubits/tests/test_cpu_switch.py
+++ b/scqubits/tests/test_cpu_switch.py
@@ -21,6 +21,7 @@ import scqubits.utils.cpu_switch as cpu_switch
 from scqubits.utils.cpu_switch import (
     _BLAS_THREAD_ENV_VARS,
     _capped_blas_threads,
+    _resolve_start_method,
     _validated_blas_thread_cap,
 )
 
@@ -135,3 +136,42 @@ class TestShutdownPool:
 class TestGetMapMethodSerial:
     def test_num_cpus_one_returns_builtin_map(self):
         assert cpu_switch.get_map_method(1) is map
+
+
+class TestResolveStartMethod:
+    def test_explicit_override(self, monkeypatch):
+        for method in cpu_switch._backend_module().get_all_start_methods():
+            monkeypatch.setattr(settings, "MULTIPROC_START_METHOD", method)
+            assert _resolve_start_method() == method
+
+    def test_unavailable_override_falls_back(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_START_METHOD", "not-a-method")
+        assert (
+            _resolve_start_method()
+            in cpu_switch._backend_module().get_all_start_methods()
+        )
+
+    def test_platform_default(self, monkeypatch):
+        import sys
+
+        monkeypatch.setattr(settings, "MULTIPROC_START_METHOD", None)
+        method = _resolve_start_method()
+        if sys.platform.startswith("linux"):
+            assert method == "fork"
+        else:
+            # macOS / Windows default to spawn (fork-after-threads is unsafe on macOS)
+            assert method == "spawn"
+
+
+class TestPoolReuseSignature:
+    def test_reusable_matches_signature(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC", "pathos")
+        monkeypatch.setattr(settings, "MULTIPROC_START_METHOD", None)
+        method = _resolve_start_method()
+        monkeypatch.setattr(cpu_switch, "_pool_signature", ("pathos", method, 4))
+        assert cpu_switch._pool_is_reusable(object(), 4) is True
+        assert cpu_switch._pool_is_reusable(object(), 2) is False  # different cpu count
+
+    def test_not_reusable_when_unset(self, monkeypatch):
+        monkeypatch.setattr(cpu_switch, "_pool_signature", None)
+        assert cpu_switch._pool_is_reusable(object(), 4) is False

--- a/scqubits/tests/test_cpu_switch.py
+++ b/scqubits/tests/test_cpu_switch.py
@@ -139,6 +139,25 @@ class TestGetMapMethodSerial:
         assert cpu_switch.get_map_method(1) is map
 
 
+class TestImapChunksize:
+    class _FakePool:
+        def imap(self, func, iterable, chunksize=1):
+            return ("imap", chunksize)
+
+    def test_total_none_uses_default_chunksize(self):
+        mapper = cpu_switch._imap_with_chunksize(self._FakePool(), 4, None)
+        assert mapper("f", "it")[1] == 1  # imap's own default
+
+    def test_chunksize_matches_map_heuristic(self):
+        # pool.map uses ceil(total / (4 * num_cpus)); 384 / 16 -> 24
+        mapper = cpu_switch._imap_with_chunksize(self._FakePool(), 4, 384)
+        assert mapper("f", "it")[1] == 24
+
+    def test_chunksize_floored_at_one(self):
+        mapper = cpu_switch._imap_with_chunksize(self._FakePool(), 4, 3)
+        assert mapper("f", "it")[1] == 1
+
+
 class TestResolveStartMethod:
     def test_resolves_to_available_method(self):
         assert (

--- a/scqubits/tests/test_cpu_switch.py
+++ b/scqubits/tests/test_cpu_switch.py
@@ -1,0 +1,137 @@
+# test_cpu_switch.py
+# meant to be run with 'pytest'
+#
+# This file is part of scqubits: a Python package for superconducting qubits,
+# Quantum 5, 583 (2021). https://quantum-journal.org/papers/q-2021-11-17-583/
+#
+#    Copyright (c) 2019 and later, Jens Koch and Peter Groszkowski
+#    All rights reserved.
+#
+#    This source code is licensed under the BSD-style license found in the
+#    LICENSE file in the root directory of this source tree.
+############################################################################
+
+import os
+
+import pytest
+
+import scqubits.settings as settings
+import scqubits.utils.cpu_switch as cpu_switch
+
+from scqubits.utils.cpu_switch import (
+    _BLAS_THREAD_ENV_VARS,
+    _capped_blas_threads,
+    _validated_blas_thread_cap,
+)
+
+
+class TestValidatedBlasThreadCap:
+    def test_none_returns_none(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", None)
+        assert _validated_blas_thread_cap() is None
+
+    def test_positive_int_passes_through(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 3)
+        assert _validated_blas_thread_cap() == 3
+
+    @pytest.mark.parametrize("bad", [1.5, "2", [1], 2.0])
+    def test_non_int_rejected(self, monkeypatch, bad):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", bad)
+        with pytest.raises(TypeError):
+            _validated_blas_thread_cap()
+
+    def test_bool_rejected(self, monkeypatch):
+        # bool is an int subclass; True must not be silently treated as 1
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", True)
+        with pytest.raises(TypeError):
+            _validated_blas_thread_cap()
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_non_positive_rejected(self, monkeypatch, bad):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", bad)
+        with pytest.raises(ValueError):
+            _validated_blas_thread_cap()
+
+
+class TestCappedBlasThreads:
+    def test_noop_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", None)
+        monkeypatch.delenv("OPENBLAS_NUM_THREADS", raising=False)
+        with _capped_blas_threads():
+            assert "OPENBLAS_NUM_THREADS" not in os.environ
+
+    def test_sets_cap_inside_and_removes_after_when_unset_before(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 2)
+        for var in _BLAS_THREAD_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        with _capped_blas_threads():
+            for var in _BLAS_THREAD_ENV_VARS:
+                assert os.environ[var] == "2"
+        # vars that were unset before the block must be removed again
+        for var in _BLAS_THREAD_ENV_VARS:
+            assert var not in os.environ
+
+    def test_restores_preexisting_value(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 1)
+        monkeypatch.setenv("OPENBLAS_NUM_THREADS", "7")
+        with _capped_blas_threads():
+            assert os.environ["OPENBLAS_NUM_THREADS"] == "1"
+        # a value present before the block must be restored, not deleted
+        assert os.environ["OPENBLAS_NUM_THREADS"] == "7"
+
+    def test_restores_environment_on_exception(self, monkeypatch):
+        monkeypatch.setattr(settings, "MULTIPROC_BLAS_THREADS", 1)
+        monkeypatch.delenv("OPENBLAS_NUM_THREADS", raising=False)
+        with pytest.raises(RuntimeError):
+            with _capped_blas_threads():
+                raise RuntimeError("boom")
+        assert "OPENBLAS_NUM_THREADS" not in os.environ
+
+
+class TestShutdownCachedPool:
+    def test_noop_when_no_pool(self, monkeypatch):
+        monkeypatch.setattr(settings, "POOL", None)
+        cpu_switch._shutdown_cached_pool()  # must not raise
+        assert settings.POOL is None
+
+    def test_shuts_down_and_clears_cached_pool(self, monkeypatch):
+        class FakePool:
+            def __init__(self):
+                self.terminated = False
+
+            def terminate(self):
+                self.terminated = True
+
+            def close(self):
+                pass
+
+            def clear(self):
+                pass
+
+        pool = FakePool()
+        monkeypatch.setattr(settings, "POOL", pool)
+        cpu_switch._shutdown_cached_pool()
+        assert pool.terminated is True
+        assert settings.POOL is None
+
+
+class TestShutdownPool:
+    def test_cleanup_failure_is_logged_not_raised(self, caplog):
+        class BadPool:
+            def terminate(self):
+                raise RuntimeError("boom")
+
+            def close(self):
+                pass
+
+            def clear(self):
+                pass
+
+        with caplog.at_level("WARNING"):
+            cpu_switch._shutdown_pool(BadPool())  # must not raise
+        assert any("cleanup" in record.message for record in caplog.records)
+
+
+class TestGetMapMethodSerial:
+    def test_num_cpus_one_returns_builtin_map(self):
+        assert cpu_switch.get_map_method(1) is map

--- a/scqubits/tests/test_parametersweep.py
+++ b/scqubits/tests/test_parametersweep.py
@@ -267,3 +267,69 @@ class TestProgressBarParallelDispatch:
         # completed without a pickling error, and self retains no progress bars
         assert not hasattr(sweep, "_progress_bars")
         assert sweep["evals"].shape[0] == 6
+
+
+class TestRunExceptionSafety:
+    def test_dispatch_enabled_restored_when_sweep_raises(self, monkeypatch):
+        # A sweep that raises mid-run must still restore settings.DISPATCH_ENABLED,
+        # or every later sweep in the kernel is silently poisoned.
+        monkeypatch.setattr(scq.settings, "DISPATCH_ENABLED", True)
+        q = scq.TunableTransmon(
+            EJmax=30.0, EC=0.2, d=0.1, flux=0.0, ng=0.0, ncut=20, truncated_dim=3
+        )
+        hs = scq.HilbertSpace([q])
+
+        def boom(flux):
+            raise RuntimeError("boom")
+
+        sweep = scq.ParameterSweep(
+            hilbertspace=hs,
+            paramvals_by_name={"flux": np.linspace(0.0, 0.4, 4)},
+            update_hilbertspace=boom,
+            evals_count=3,
+            num_cpus=1,
+            autorun=False,
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            sweep.run()
+        assert scq.settings.DISPATCH_ENABLED is True
+
+    def test_consume_with_bar_closes_bar_on_exception(self, monkeypatch):
+        import scqubits.core.param_sweep as ps_mod
+
+        closed = {"value": False}
+
+        class FakeBar:
+            def __init__(self, **kwargs):
+                pass
+
+            def update(self, n):
+                pass
+
+            def refresh(self):
+                pass
+
+            def close(self):
+                closed["value"] = True
+
+        monkeypatch.setattr(ps_mod, "tqdm", lambda **kwargs: FakeBar(**kwargs))
+        q = scq.TunableTransmon(
+            EJmax=30.0, EC=0.2, d=0.1, flux=0.0, ng=0.0, ncut=20, truncated_dim=3
+        )
+        hs = scq.HilbertSpace([q])
+        sweep = scq.ParameterSweep(
+            hilbertspace=hs,
+            paramvals_by_name={"flux": np.array([0.0, 0.1])},
+            update_hilbertspace=lambda f: setattr(q, "flux", f),
+            evals_count=3,
+            num_cpus=1,
+            autorun=False,
+        )
+
+        def raising():
+            yield 1
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            sweep._consume_with_bar(raising(), 2, "x", [])
+        assert closed["value"] is True

--- a/scqubits/tests/test_parametersweep.py
+++ b/scqubits/tests/test_parametersweep.py
@@ -229,3 +229,41 @@ class TestParameterSweep:
         # Tuple-shape errors still fire.
         with pytest.raises(ValueError, match="number of subsystems"):
             sweep._validate_states(initial=(0, 0), final=None)
+
+
+class TestProgressBarParallelDispatch:
+    """Progress bars must never be stored on the ParameterSweep instance.
+
+    A tqdm bar holds an unpicklable lock (and, as a notebook widget, an ipywidgets
+    comm), while the worker tasks pickle ``self`` during parallel dispatch. With the
+    deferred-close path active (IN_IPYTHON) a multi-subsystem ``num_cpus > 1`` sweep
+    pickles ``self`` after the first phase bar would have been registered, so storing
+    bars on the instance breaks the sweep.
+    """
+
+    def test_parallel_multisubsys_sweep_with_bars_pickles(self, monkeypatch):
+        monkeypatch.setattr(scq.settings, "IN_IPYTHON", True)
+        monkeypatch.setattr(scq.settings, "PROGRESSBAR_DISABLED", False)
+
+        q1 = scq.TunableTransmon(
+            EJmax=30.0, EC=0.2, d=0.1, flux=0.0, ng=0.0, ncut=30, truncated_dim=4
+        )
+        q2 = scq.TunableTransmon(
+            EJmax=20.0, EC=0.2, d=0.1, flux=0.0, ng=0.0, ncut=30, truncated_dim=4
+        )
+        hs = scq.HilbertSpace([q1, q2])
+        hs.add_interaction(g_strength=0.1, op1=q1.n_operator, op2=q2.n_operator)
+
+        def update(flux):
+            q1.flux = flux
+
+        sweep = scq.ParameterSweep(
+            hilbertspace=hs,
+            paramvals_by_name={"flux": np.linspace(0.0, 0.4, 6)},
+            update_hilbertspace=update,
+            evals_count=8,
+            num_cpus=2,  # real parallel dispatch -> pickles self
+        )
+        # completed without a pickling error, and self retains no progress bars
+        assert not hasattr(sweep, "_progress_bars")
+        assert sweep["evals"].shape[0] == 6

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 import atexit
 import logging
 import os
+import warnings
 
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
-from typing import Optional
+from contextlib import contextmanager, nullcontext
+from typing import Any, ContextManager, Optional
 
 import scqubits.settings as settings
 
@@ -31,6 +32,9 @@ _BLAS_THREAD_ENV_VARS = (
     "OMP_NUM_THREADS",
     "NUMEXPR_NUM_THREADS",
 )
+
+# The "BLAS-thread cap cannot take effect" warning is emitted at most once.
+_blas_cap_ineffective_warned = False
 
 
 def get_map_method(num_cpus: int) -> Callable:
@@ -132,26 +136,110 @@ def _validated_blas_thread_cap() -> Optional[int]:
     return threads
 
 
+def _import_threadpoolctl() -> Optional[Any]:
+    """Return the ``threadpoolctl`` module if installed, else ``None``."""
+    try:
+        import threadpoolctl
+    except ImportError:
+        return None
+    return threadpoolctl
+
+
+def _worker_start_method() -> str:
+    """Return the process start method of the configured multiprocessing backend.
+
+    Returns
+    -------
+    ``'fork'``, ``'spawn'``, ``'forkserver'``, or ``''`` if it cannot be queried.
+    The pathos backend uses ``multiprocess``, whose default can differ from the
+    standard-library ``multiprocessing`` default (notably fork on macOS).
+    """
+    module_name = (
+        "multiprocess" if settings.MULTIPROC == "pathos" else "multiprocessing"
+    )
+    try:
+        import importlib
+
+        return importlib.import_module(module_name).get_start_method() or ""
+    except Exception:
+        return ""
+
+
+def _warn_blas_cap_ineffective(threads: int) -> None:
+    """Warn (once) when the requested BLAS-thread cap cannot take effect.
+
+    Capping relies on either ``threadpoolctl`` (which retunes OpenBLAS/MKL/OpenMP
+    in the parent before workers fork) or spawn-based workers that re-read the
+    environment. It cannot work when numpy's BLAS exposes no controller (e.g. Apple
+    Accelerate) or when workers are fork-based and ``threadpoolctl`` is unavailable.
+
+    Parameters
+    ----------
+    threads:
+        the requested per-worker thread cap, used only in the warning message.
+    """
+    global _blas_cap_ineffective_warned
+    if _blas_cap_ineffective_warned:
+        return
+    threadpoolctl = _import_threadpoolctl()
+    reason = ""
+    if threadpoolctl is not None:
+        if not threadpoolctl.threadpool_info():
+            reason = (
+                "numpy's BLAS backend exposes no thread control (e.g. Apple "
+                "Accelerate)"
+            )
+    elif _worker_start_method() == "fork":
+        reason = (
+            "workers are fork-based and 'threadpoolctl' is not installed; install "
+            "it (pip install threadpoolctl) to cap threads in forked workers, or "
+            "export OPENBLAS_NUM_THREADS/MKL_NUM_THREADS before importing scqubits"
+        )
+    if reason:
+        warnings.warn(
+            "settings.MULTIPROC_BLAS_THREADS={} has no effect here: {}.".format(
+                threads, reason
+            ),
+            stacklevel=3,
+        )
+        _blas_cap_ineffective_warned = True
+
+
 @contextmanager
 def _capped_blas_threads() -> Iterator[None]:
-    """Temporarily cap worker BLAS/OpenMP threads via the environment.
+    """Temporarily cap worker BLAS/OpenMP threads while a pool is created.
 
-    The thread-count environment variables are set on entry and restored to their
-    prior values on exit, so the cap applies only to worker processes created
-    inside the ``with`` block (they capture the capped environment as they fork or
-    spawn) and never permanently alters the parent process's environment. No-op
-    when ``settings.MULTIPROC_BLAS_THREADS`` is ``None``.
+    Two mechanisms are combined so the cap reaches workers regardless of start
+    method:
+
+    - the thread-count environment variables are set on entry and restored on
+      exit, which spawn-based workers re-read when they re-import numpy;
+    - if ``threadpoolctl`` is installed, the parent's BLAS/OpenMP thread count is
+      limited for the duration of the block, so fork-based workers inherit the
+      reduced count.
+
+    Neither the parent environment nor its thread-pool settings are altered after
+    the block exits. No-op when ``settings.MULTIPROC_BLAS_THREADS`` is ``None``; a
+    warning is emitted when the cap cannot take effect on the current platform.
     """
     threads = _validated_blas_thread_cap()
     if threads is None:
         yield
         return
+    _warn_blas_cap_ineffective(threads)
     value = str(threads)
     saved = {var: os.environ.get(var) for var in _BLAS_THREAD_ENV_VARS}
     for var in _BLAS_THREAD_ENV_VARS:
         os.environ[var] = value
+    threadpoolctl = _import_threadpoolctl()
+    limiter: ContextManager[Any] = (
+        threadpoolctl.threadpool_limits(limits=threads)
+        if threadpoolctl is not None
+        else nullcontext()
+    )
     try:
-        yield
+        with limiter:
+            yield
     finally:
         for var, original in saved.items():
             if original is None:

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -12,11 +12,25 @@
 
 from __future__ import annotations
 
+import atexit
+import logging
 import os
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Optional
 
 import scqubits.settings as settings
+
+LOGGER = logging.getLogger(__name__)
+
+# Environment variables read by the common BLAS/OpenMP backends at numpy import.
+_BLAS_THREAD_ENV_VARS = (
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OMP_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+)
 
 
 def get_map_method(num_cpus: int) -> Callable:
@@ -68,7 +82,17 @@ def _pool_is_reusable(pool: object, num_cpus: int) -> bool:
 
 
 def _shutdown_pool(pool: object) -> None:
-    """Terminate a pool that is about to be discarded; never raise on cleanup."""
+    """Terminate a pool that is about to be discarded.
+
+    Cleanup failures are logged rather than raised, so discarding a pool never
+    interrupts the caller, while a failure that could leak worker processes still
+    leaves a diagnostic trail.
+
+    Parameters
+    ----------
+    pool:
+        pool object to shut down; missing cleanup methods are skipped.
+    """
     for method_name in ("terminate", "close", "clear"):
         method = getattr(pool, method_name, None)
         if method is None:
@@ -76,50 +100,114 @@ def _shutdown_pool(pool: object) -> None:
         try:
             method()
         except Exception:
-            pass
+            LOGGER.warning(
+                "scqubits: worker-pool cleanup via %s() failed; worker processes "
+                "may linger.",
+                method_name,
+                exc_info=True,
+            )
 
 
-def _apply_blas_thread_cap() -> None:
-    """Cap worker BLAS/OpenMP threads via the environment before workers spawn.
+def _validated_blas_thread_cap() -> Optional[int]:
+    """Return the validated ``settings.MULTIPROC_BLAS_THREADS`` value.
 
-    Spawn-based workers (the default on Windows) re-import numpy and read these
-    variables at import, so capping here keeps ``num_cpus`` workers from each
-    launching a full BLAS thread pool and oversubscribing the cores. No-op when
-    ``settings.MULTIPROC_BLAS_THREADS`` is ``None``.
+    Returns
+    -------
+    The configured positive thread cap, or ``None`` when capping is disabled.
     """
     threads = getattr(settings, "MULTIPROC_BLAS_THREADS", None)
     if threads is None:
+        return None
+    # bool is an int subclass; reject it explicitly to avoid True -> 1 surprises.
+    if isinstance(threads, bool) or not isinstance(threads, int):
+        raise TypeError(
+            "settings.MULTIPROC_BLAS_THREADS must be a positive int or None, got "
+            "{!r}".format(threads)
+        )
+    if threads < 1:
+        raise ValueError(
+            "settings.MULTIPROC_BLAS_THREADS must be a positive int or None, got "
+            "{}".format(threads)
+        )
+    return threads
+
+
+@contextmanager
+def _capped_blas_threads() -> Iterator[None]:
+    """Temporarily cap worker BLAS/OpenMP threads via the environment.
+
+    The thread-count environment variables are set on entry and restored to their
+    prior values on exit, so the cap applies only to worker processes created
+    inside the ``with`` block (they capture the capped environment as they fork or
+    spawn) and never permanently alters the parent process's environment. No-op
+    when ``settings.MULTIPROC_BLAS_THREADS`` is ``None``.
+    """
+    threads = _validated_blas_thread_cap()
+    if threads is None:
+        yield
         return
-    value = str(int(threads))
-    for var in (
-        "OPENBLAS_NUM_THREADS",
-        "MKL_NUM_THREADS",
-        "OMP_NUM_THREADS",
-        "NUMEXPR_NUM_THREADS",
-    ):
+    value = str(threads)
+    saved = {var: os.environ.get(var) for var in _BLAS_THREAD_ENV_VARS}
+    for var in _BLAS_THREAD_ENV_VARS:
         os.environ[var] = value
+    try:
+        yield
+    finally:
+        for var, original in saved.items():
+            if original is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = original
 
 
 def _new_pool(num_cpus: int) -> object:
-    """Start a fresh pool of the configured kind."""
-    _apply_blas_thread_cap()
-    if settings.MULTIPROC == "pathos":
-        try:
-            import dill
-            import pathos
-        except ImportError:
-            raise ImportError(
-                "scqubits multiprocessing mode set to 'pathos'. Need but cannot find"
-                " 'pathos'/'dill'!"
-            )
-        dill.settings["recurse"] = True
-        return pathos.pools.ProcessPool(nodes=num_cpus)
-    if settings.MULTIPROC == "multiprocessing":
-        import multiprocessing
+    """Start a fresh pool of the configured kind.
 
-        return multiprocessing.Pool(processes=num_cpus)
+    The BLAS/OpenMP thread cap is applied only while the worker processes are
+    created (they capture the capped environment as they spawn or fork); the parent
+    process's environment is restored immediately afterwards.
+
+    Parameters
+    ----------
+    num_cpus:
+        number of worker processes for the new pool.
+
+    Returns
+    -------
+    A freshly started pathos or multiprocessing pool, selected by
+    ``settings.MULTIPROC``.
+    """
+    with _capped_blas_threads():
+        if settings.MULTIPROC == "pathos":
+            try:
+                import dill
+                import pathos
+            except ImportError:
+                raise ImportError(
+                    "scqubits multiprocessing mode set to 'pathos'. Need but cannot"
+                    " find 'pathos'/'dill'!"
+                )
+            dill.settings["recurse"] = True
+            return pathos.pools.ProcessPool(nodes=num_cpus)
+        if settings.MULTIPROC == "multiprocessing":
+            import multiprocessing
+
+            return multiprocessing.Pool(processes=num_cpus)
     raise ValueError(
         "Unknown multiprocessing type: settings.MULTIPROC = {}".format(
             settings.MULTIPROC
         )
     )
+
+
+@atexit.register
+def _shutdown_cached_pool() -> None:
+    """Shut down the worker pool cached in ``settings.POOL`` at interpreter exit.
+
+    Without this, the reused pool's worker processes outlive the interpreter and
+    are only reaped by the operating system.
+    """
+    pool = settings.POOL
+    if pool is not None:
+        _shutdown_pool(pool)
+        settings.POOL = None

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -19,27 +19,66 @@ import scqubits.settings as settings
 
 def get_map_method(num_cpus: int) -> Callable:
     """Selects the correct `.map` method depending on the specified number of desired
-    cores. If num_cpus>1, the multiprocessing/pathos pool is started here.
+    cores. If num_cpus>1, a multiprocessing/pathos pool is used.
+
+    A pool created here is cached in ``settings.POOL`` and reused on subsequent
+    calls that request the same worker count and backend, rather than spawning a
+    fresh pool every time (a single ``ParameterSweep.run`` otherwise starts one
+    pool per bare-subsystem sweep plus the dressed sweep). When the cached pool no
+    longer matches the request it is shut down before a new one is started.
 
     Parameters
     ----------
     num_cpus:
         number of worker processes requested by the caller; ``1``
-        returns the built-in ``map``, ``> 1`` starts a multiprocessing
+        returns the built-in ``map``, ``> 1`` uses a multiprocessing
         pool of the configured kind.
 
     Returns
     -------
     A ``.map``-style callable to be used by the caller.  For
     ``num_cpus == 1`` this is the built-in ``map``; otherwise it is
-    the bound ``map`` method of a freshly-started pathos or
+    the bound ``map`` method of a cached or freshly-started pathos or
     multiprocessing pool (selected by ``settings.MULTIPROC``).
     """
     if num_cpus == 1:
         return map
 
     # num_cpus > 1 -----------------
-    # user is asking for more than 1 cpu; start pool from here
+    existing_pool = settings.POOL
+    if existing_pool is not None:
+        if _pool_is_reusable(existing_pool, num_cpus):
+            return existing_pool.map
+        _shutdown_pool(existing_pool)
+        settings.POOL = None
+
+    settings.POOL = _new_pool(num_cpus)
+    return settings.POOL.map
+
+
+def _pool_is_reusable(pool: object, num_cpus: int) -> bool:
+    """Return True if the cached pool matches the configured backend and cpu count."""
+    if settings.MULTIPROC == "pathos":
+        return getattr(pool, "nodes", None) == num_cpus
+    if settings.MULTIPROC == "multiprocessing":
+        return getattr(pool, "_processes", None) == num_cpus
+    return False
+
+
+def _shutdown_pool(pool: object) -> None:
+    """Terminate a pool that is about to be discarded; never raise on cleanup."""
+    for method_name in ("terminate", "close", "clear"):
+        method = getattr(pool, method_name, None)
+        if method is None:
+            continue
+        try:
+            method()
+        except Exception:
+            pass
+
+
+def _new_pool(num_cpus: int) -> object:
+    """Start a fresh pool of the configured kind."""
     if settings.MULTIPROC == "pathos":
         try:
             import dill
@@ -49,18 +88,14 @@ def get_map_method(num_cpus: int) -> Callable:
                 "scqubits multiprocessing mode set to 'pathos'. Need but cannot find"
                 " 'pathos'/'dill'!"
             )
-        else:
-            dill.settings["recurse"] = True
-            settings.POOL = pathos.pools.ProcessPool(nodes=num_cpus)
-            return settings.POOL.map
+        dill.settings["recurse"] = True
+        return pathos.pools.ProcessPool(nodes=num_cpus)
     if settings.MULTIPROC == "multiprocessing":
         import multiprocessing
 
-        settings.POOL = multiprocessing.Pool(processes=num_cpus)
-        return settings.POOL.map
-    else:
-        raise ValueError(
-            "Unknown multiprocessing type: settings.MULTIPROC = {}".format(
-                settings.MULTIPROC
-            )
+        return multiprocessing.Pool(processes=num_cpus)
+    raise ValueError(
+        "Unknown multiprocessing type: settings.MULTIPROC = {}".format(
+            settings.MULTIPROC
         )
+    )

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -171,10 +171,11 @@ def _backend_module() -> Any:
 def _resolve_start_method() -> str:
     """Return the process start method the worker pool will use.
 
-    Uses ``settings.MULTIPROC_START_METHOD`` when set, otherwise a platform default:
-    ``'fork'`` on Linux, ``'spawn'`` on macOS and Windows (fork-after-threads is
-    unsafe on macOS). Falls back to an available method if the requested one is not
-    supported by the backend on this platform.
+    This is a platform fact, not a tuning knob: ``'fork'`` on Linux, ``'spawn'`` on
+    macOS and Windows. macOS uses spawn because fork-after-threads is unsafe with
+    Apple's frameworks (Accelerate/GCD, the Objective-C runtime) and can crash or
+    hang; Windows supports only spawn. Falls back to an available method if the
+    platform default is somehow unsupported by the backend.
 
     Returns
     -------
@@ -184,12 +185,10 @@ def _resolve_start_method() -> str:
         available = set(_backend_module().get_all_start_methods())
     except Exception:
         available = set()
-    requested = getattr(settings, "MULTIPROC_START_METHOD", None)
-    if requested is None:
-        requested = "fork" if sys.platform.startswith("linux") else "spawn"
-    if available and requested not in available:
-        requested = "spawn" if "spawn" in available else next(iter(available))
-    return requested
+    method = "fork" if sys.platform.startswith("linux") else "spawn"
+    if available and method not in available:
+        method = "spawn" if "spawn" in available else next(iter(available))
+    return method
 
 
 def _worker_start_method() -> str:
@@ -220,21 +219,20 @@ def _warn_blas_cap_ineffective(threads: int) -> None:
     # import, so the env-var cap is effective regardless of the BLAS backend.
     if _worker_start_method() in ("spawn", "forkserver"):
         return
-    # fork: workers inherit the parent's already-initialized BLAS; the env-var cap is
-    # inert, so capping relies on threadpoolctl being able to retune the loaded BLAS.
+    # fork (Linux): workers inherit the parent's already-initialized BLAS; the env-var
+    # cap is inert, so capping relies on threadpoolctl retuning the loaded BLAS.
     threadpoolctl = _import_threadpoolctl()
     reason = ""
     if threadpoolctl is None:
         reason = (
             "workers are fork-based and 'threadpoolctl' is not installed; install it "
-            "(pip install threadpoolctl), export OPENBLAS_NUM_THREADS/MKL_NUM_THREADS "
-            "before importing scqubits, or set "
-            "scqubits.settings.MULTIPROC_START_METHOD = 'spawn'"
+            "(pip install threadpoolctl), or export OPENBLAS_NUM_THREADS/MKL_NUM_THREADS "
+            "before importing scqubits"
         )
     elif not threadpoolctl.threadpool_info():
         reason = (
-            "workers are fork-based and numpy's BLAS exposes no thread control (e.g. "
-            "Apple Accelerate); set scqubits.settings.MULTIPROC_START_METHOD = 'spawn'"
+            "workers are fork-based and numpy's BLAS exposes no thread control; export "
+            "OPENBLAS_NUM_THREADS/MKL_NUM_THREADS before importing scqubits"
         )
     if reason:
         warnings.warn(
@@ -315,8 +313,7 @@ def _warn_spawn_guard(method: str) -> None:
         "plain Python script, its entry point must be guarded:\n\n"
         '    if __name__ == "__main__":\n'
         "        ...   # code that triggers num_cpus > 1\n\n"
-        "Jupyter/IPython need no guard. To use fork instead, set "
-        "scqubits.settings.MULTIPROC_START_METHOD = 'fork'.".format(method),
+        "Jupyter/IPython need no guard.".format(method),
         stacklevel=3,
     )
     _spawn_guard_warned = True

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -13,8 +13,10 @@
 from __future__ import annotations
 
 import atexit
+import importlib
 import logging
 import os
+import sys
 import warnings
 
 from collections.abc import Callable, Iterator
@@ -24,6 +26,10 @@ from typing import Any, ContextManager, Optional
 import scqubits.settings as settings
 
 LOGGER = logging.getLogger(__name__)
+
+# Backend + start method + cpu count of the pool cached in settings.POOL, so reuse
+# does not depend on reading private pool attributes.
+_pool_signature: Optional[tuple] = None
 
 # Environment variables read by the common BLAS/OpenMP backends at numpy import.
 _BLAS_THREAD_ENV_VARS = (
@@ -77,12 +83,16 @@ def get_map_method(num_cpus: int) -> Callable:
 
 
 def _pool_is_reusable(pool: object, num_cpus: int) -> bool:
-    """Return True if the cached pool matches the configured backend and cpu count."""
-    if settings.MULTIPROC == "pathos":
-        return getattr(pool, "nodes", None) == num_cpus
-    if settings.MULTIPROC == "multiprocessing":
-        return getattr(pool, "_processes", None) == num_cpus
-    return False
+    """Return True if the cached pool matches the requested backend, start method, cpu count.
+
+    Parameters
+    ----------
+    pool:
+        the cached pool object (unused; reuse is tracked via ``_pool_signature``).
+    num_cpus:
+        number of worker processes requested by the caller.
+    """
+    return _pool_signature == (settings.MULTIPROC, _resolve_start_method(), num_cpus)
 
 
 def _shutdown_pool(pool: object) -> None:
@@ -145,22 +155,44 @@ def _import_threadpoolctl() -> Optional[Any]:
     return threadpoolctl
 
 
-def _worker_start_method() -> str:
-    """Return the process start method of the configured multiprocessing backend.
+def _backend_module() -> Any:
+    """Return the multiprocessing backend module.
+
+    ``multiprocess`` (the dill-backed engine) for the pathos backend, otherwise the
+    standard-library ``multiprocessing``.
+    """
+    name = "multiprocess" if settings.MULTIPROC == "pathos" else "multiprocessing"
+    return importlib.import_module(name)
+
+
+def _resolve_start_method() -> str:
+    """Return the process start method the worker pool will use.
+
+    Uses ``settings.MULTIPROC_START_METHOD`` when set, otherwise a platform default:
+    ``'fork'`` on Linux, ``'spawn'`` on macOS and Windows (fork-after-threads is
+    unsafe on macOS). Falls back to an available method if the requested one is not
+    supported by the backend on this platform.
 
     Returns
     -------
-    ``'fork'``, ``'spawn'``, ``'forkserver'``, or ``''`` if it cannot be queried.
-    The pathos backend uses ``multiprocess``, whose default can differ from the
-    standard-library ``multiprocessing`` default (notably fork on macOS).
+    One of ``'fork'``, ``'spawn'``, ``'forkserver'``.
     """
-    module_name = (
-        "multiprocess" if settings.MULTIPROC == "pathos" else "multiprocessing"
-    )
     try:
-        import importlib
+        available = set(_backend_module().get_all_start_methods())
+    except Exception:
+        available = set()
+    requested = getattr(settings, "MULTIPROC_START_METHOD", None)
+    if requested is None:
+        requested = "fork" if sys.platform.startswith("linux") else "spawn"
+    if available and requested not in available:
+        requested = "spawn" if "spawn" in available else next(iter(available))
+    return requested
 
-        return importlib.import_module(module_name).get_start_method() or ""
+
+def _worker_start_method() -> str:
+    """Return the start method the worker pool will use, or ``''`` if it can't be queried."""
+    try:
+        return _resolve_start_method()
     except Exception:
         return ""
 
@@ -181,19 +213,25 @@ def _warn_blas_cap_ineffective(threads: int) -> None:
     global _blas_cap_ineffective_warned
     if _blas_cap_ineffective_warned:
         return
+    # spawn/forkserver workers re-import numpy/scipy and read the thread env vars at
+    # import, so the env-var cap is effective regardless of the BLAS backend.
+    if _worker_start_method() in ("spawn", "forkserver"):
+        return
+    # fork: workers inherit the parent's already-initialized BLAS; the env-var cap is
+    # inert, so capping relies on threadpoolctl being able to retune the loaded BLAS.
     threadpoolctl = _import_threadpoolctl()
     reason = ""
-    if threadpoolctl is not None:
-        if not threadpoolctl.threadpool_info():
-            reason = (
-                "numpy's BLAS backend exposes no thread control (e.g. Apple "
-                "Accelerate)"
-            )
-    elif _worker_start_method() == "fork":
+    if threadpoolctl is None:
         reason = (
-            "workers are fork-based and 'threadpoolctl' is not installed; install "
-            "it (pip install threadpoolctl) to cap threads in forked workers, or "
-            "export OPENBLAS_NUM_THREADS/MKL_NUM_THREADS before importing scqubits"
+            "workers are fork-based and 'threadpoolctl' is not installed; install it "
+            "(pip install threadpoolctl), export OPENBLAS_NUM_THREADS/MKL_NUM_THREADS "
+            "before importing scqubits, or set "
+            "scqubits.settings.MULTIPROC_START_METHOD = 'spawn'"
+        )
+    elif not threadpoolctl.threadpool_info():
+        reason = (
+            "workers are fork-based and numpy's BLAS exposes no thread control (e.g. "
+            "Apple Accelerate); set scqubits.settings.MULTIPROC_START_METHOD = 'spawn'"
         )
     if reason:
         warnings.warn(
@@ -249,11 +287,17 @@ def _capped_blas_threads() -> Iterator[None]:
 
 
 def _new_pool(num_cpus: int) -> object:
-    """Start a fresh pool of the configured kind.
+    """Start a fresh worker pool of the configured backend and start method.
 
-    The BLAS/OpenMP thread cap is applied only while the worker processes are
-    created (they capture the capped environment as they spawn or fork); the parent
-    process's environment is restored immediately afterwards.
+    The pool is created from an explicit process context (see
+    :func:`_resolve_start_method`) so the start method is *chosen* rather than
+    inherited -- notably ``'spawn'`` on macOS, where fork-after-threads is unsafe.
+    The pathos backend uses ``multiprocess`` (dill-backed), so worker closures still
+    pickle under spawn.
+
+    The BLAS/OpenMP thread cap is applied only while the worker processes are created
+    (they capture the capped environment as they spawn or fork); the parent process's
+    environment is restored immediately afterwards.
 
     Parameters
     ----------
@@ -262,30 +306,32 @@ def _new_pool(num_cpus: int) -> object:
 
     Returns
     -------
-    A freshly started pathos or multiprocessing pool, selected by
-    ``settings.MULTIPROC``.
+    A freshly started pool whose ``.map`` method is used by the caller.
     """
+    global _pool_signature
+    if settings.MULTIPROC not in ("pathos", "multiprocessing"):
+        raise ValueError(
+            "Unknown multiprocessing type: settings.MULTIPROC = {}".format(
+                settings.MULTIPROC
+            )
+        )
+    method = _resolve_start_method()
     with _capped_blas_threads():
         if settings.MULTIPROC == "pathos":
             try:
                 import dill
-                import pathos
+                import multiprocess as backend
             except ImportError:
                 raise ImportError(
                     "scqubits multiprocessing mode set to 'pathos'. Need but cannot"
                     " find 'pathos'/'dill'!"
                 )
             dill.settings["recurse"] = True
-            return pathos.pools.ProcessPool(nodes=num_cpus)
-        if settings.MULTIPROC == "multiprocessing":
-            import multiprocessing
-
-            return multiprocessing.Pool(processes=num_cpus)
-    raise ValueError(
-        "Unknown multiprocessing type: settings.MULTIPROC = {}".format(
-            settings.MULTIPROC
-        )
-    )
+        else:
+            import multiprocessing as backend
+        pool = backend.get_context(method).Pool(processes=num_cpus)
+    _pool_signature = (settings.MULTIPROC, method, num_cpus)
+    return pool
 
 
 @atexit.register
@@ -295,7 +341,9 @@ def _shutdown_cached_pool() -> None:
     Without this, the reused pool's worker processes outlive the interpreter and
     are only reaped by the operating system.
     """
+    global _pool_signature
     pool = settings.POOL
     if pool is not None:
         _shutdown_pool(pool)
         settings.POOL = None
+        _pool_signature = None

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -123,20 +123,42 @@ def get_map_method(
     return _imap_with_chunksize(settings.POOL, num_cpus, total)
 
 
-def _effective_blas_cap(blas_threads: Optional[int]) -> Optional[int]:
-    """Return the BLAS-thread cap that will actually be applied to a worker pool.
+def _auto_blas_cap(num_cpus: int) -> int:
+    """Per-worker BLAS-thread cap that splits the cores evenly across workers.
 
-    An explicit ``blas_threads`` override takes precedence; otherwise the configured
-    ``settings.MULTIPROC_BLAS_THREADS`` is used.
+    ``max(1, cores // num_cpus)`` keeps the workers' combined thread count at about
+    one per core, so ``num_cpus`` workers never oversubscribe the machine.
 
     Parameters
     ----------
+    num_cpus:
+        number of worker processes the cap is being divided among.
+    """
+    cores = os.cpu_count() or 1
+    return max(1, cores // num_cpus)
+
+
+def _effective_blas_cap(num_cpus: int, blas_threads: Optional[int]) -> Optional[int]:
+    """Return the concrete BLAS-thread cap that will be applied to a worker pool.
+
+    An explicit ``blas_threads`` override takes precedence; otherwise
+    ``settings.MULTIPROC_BLAS_THREADS`` decides: ``"auto"`` resolves to
+    :func:`_auto_blas_cap`, a positive int is used as-is, and ``None`` disables
+    capping.
+
+    Parameters
+    ----------
+    num_cpus:
+        worker count, used to resolve the ``"auto"`` setting.
     blas_threads:
         per-pool override, or ``None`` to defer to the global setting.
     """
     if blas_threads is not None:
         return blas_threads
-    return _validated_blas_thread_cap()
+    setting = _validated_blas_thread_cap()
+    if isinstance(setting, str):  # the "auto" sentinel
+        return _auto_blas_cap(num_cpus)
+    return setting
 
 
 def _pool_is_reusable(
@@ -160,7 +182,7 @@ def _pool_is_reusable(
         settings.MULTIPROC,
         _resolve_start_method(),
         num_cpus,
-        _effective_blas_cap(blas_threads),
+        _effective_blas_cap(num_cpus, blas_threads),
     )
 
 
@@ -191,26 +213,27 @@ def _shutdown_pool(pool: object) -> None:
             )
 
 
-def _validated_blas_thread_cap() -> Optional[int]:
+def _validated_blas_thread_cap() -> "int | str | None":
     """Return the validated ``settings.MULTIPROC_BLAS_THREADS`` value.
 
     Returns
     -------
-    The configured positive thread cap, or ``None`` when capping is disabled.
+    ``"auto"`` (resolve the cap per pool from the core count), a positive int
+    (a fixed per-worker cap), or ``None`` (capping disabled).
     """
-    threads = getattr(settings, "MULTIPROC_BLAS_THREADS", None)
-    if threads is None:
-        return None
+    threads = getattr(settings, "MULTIPROC_BLAS_THREADS", "auto")
+    if threads is None or threads == "auto":
+        return threads
     # bool is an int subclass; reject it explicitly to avoid True -> 1 surprises.
     if isinstance(threads, bool) or not isinstance(threads, int):
         raise TypeError(
-            "settings.MULTIPROC_BLAS_THREADS must be a positive int or None, got "
-            "{!r}".format(threads)
+            "settings.MULTIPROC_BLAS_THREADS must be 'auto', a positive int, or None, "
+            "got {!r}".format(threads)
         )
     if threads < 1:
         raise ValueError(
-            "settings.MULTIPROC_BLAS_THREADS must be a positive int or None, got "
-            "{}".format(threads)
+            "settings.MULTIPROC_BLAS_THREADS must be 'auto', a positive int, or None, "
+            "got {}".format(threads)
         )
     return threads
 
@@ -311,7 +334,7 @@ def _warn_blas_cap_ineffective(threads: int) -> None:
 
 
 @contextmanager
-def _capped_blas_threads(override: Optional[int] = None) -> Iterator[None]:
+def _capped_blas_threads(threads: Optional[int]) -> Iterator[None]:
     """Temporarily cap worker BLAS/OpenMP threads while a pool is created.
 
     Two mechanisms are combined so the cap reaches workers regardless of start
@@ -324,16 +347,15 @@ def _capped_blas_threads(override: Optional[int] = None) -> Iterator[None]:
       reduced count.
 
     Neither the parent environment nor its thread-pool settings are altered after
-    the block exits. No-op when the effective cap is ``None``; a warning is emitted
-    when the cap cannot take effect on the current platform.
+    the block exits. No-op when ``threads`` is ``None``; a warning is emitted when
+    the cap cannot take effect on the current platform.
 
     Parameters
     ----------
-    override:
-        per-pool cap that takes precedence over ``settings.MULTIPROC_BLAS_THREADS``;
-        ``None`` defers to the global setting.
+    threads:
+        the concrete per-worker thread cap to apply (as resolved by
+        :func:`_effective_blas_cap`), or ``None`` to leave the environment untouched.
     """
-    threads = override if override is not None else _validated_blas_thread_cap()
     if threads is None:
         yield
         return
@@ -471,7 +493,8 @@ def _new_pool(num_cpus: int, blas_threads: Optional[int] = None) -> object:
     _register_pool_pickle_reduction()
     method = _resolve_start_method()
     _warn_spawn_guard(method)
-    with _capped_blas_threads(blas_threads):
+    cap = _effective_blas_cap(num_cpus, blas_threads)
+    with _capped_blas_threads(cap):
         if settings.MULTIPROC == "pathos":
             try:
                 import dill
@@ -489,7 +512,7 @@ def _new_pool(num_cpus: int, blas_threads: Optional[int] = None) -> object:
         settings.MULTIPROC,
         method,
         num_cpus,
-        _effective_blas_cap(blas_threads),
+        cap,
     )
     return pool
 

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -12,6 +12,8 @@
 
 from __future__ import annotations
 
+import os
+
 from collections.abc import Callable
 
 import scqubits.settings as settings
@@ -77,8 +79,30 @@ def _shutdown_pool(pool: object) -> None:
             pass
 
 
+def _apply_blas_thread_cap() -> None:
+    """Cap worker BLAS/OpenMP threads via the environment before workers spawn.
+
+    Spawn-based workers (the default on Windows) re-import numpy and read these
+    variables at import, so capping here keeps ``num_cpus`` workers from each
+    launching a full BLAS thread pool and oversubscribing the cores. No-op when
+    ``settings.MULTIPROC_BLAS_THREADS`` is ``None``.
+    """
+    threads = getattr(settings, "MULTIPROC_BLAS_THREADS", None)
+    if threads is None:
+        return
+    value = str(int(threads))
+    for var in (
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "OMP_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+    ):
+        os.environ[var] = value
+
+
 def _new_pool(num_cpus: int) -> object:
     """Start a fresh pool of the configured kind."""
+    _apply_blas_thread_cap()
     if settings.MULTIPROC == "pathos":
         try:
             import dill

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -481,7 +481,9 @@ def _new_pool(num_cpus: int, blas_threads: Optional[int] = None) -> object:
 
     Returns
     -------
-    A freshly started pool whose ``.map`` method is used by the caller.
+    A freshly started pool; the caller (:func:`get_map_method`) drives it through
+    ``.imap`` (with a ``map``-style chunksize) so a wrapping ``tqdm`` can advance
+    as workers finish.
     """
     global _pool_signature
     if settings.MULTIPROC not in ("pathos", "multiprocessing"):

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -138,13 +138,35 @@ def _auto_blas_cap(num_cpus: int) -> int:
     return max(1, cores // num_cpus)
 
 
+def _validate_positive_thread_int(value: Any, requirement: str) -> int:
+    """Return ``value`` if it is a positive int, else raise.
+
+    ``bool`` is an int subclass and is rejected explicitly, so ``True`` is not
+    silently treated as ``1``.
+
+    Parameters
+    ----------
+    value:
+        candidate per-worker thread count.
+    requirement:
+        the "<name> must be ..." clause used in the error message.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("{}, got {!r}".format(requirement, value))
+    if value < 1:
+        raise ValueError("{}, got {}".format(requirement, value))
+    return value
+
+
 def _effective_blas_cap(num_cpus: int, blas_threads: Optional[int]) -> Optional[int]:
     """Return the concrete BLAS-thread cap that will be applied to a worker pool.
 
     An explicit ``blas_threads`` override takes precedence; otherwise
     ``settings.MULTIPROC_BLAS_THREADS`` decides: ``"auto"`` resolves to
     :func:`_auto_blas_cap`, a positive int is used as-is, and ``None`` disables
-    capping.
+    capping. An explicit override is validated by the same rules as the setting
+    (positive int, ``bool`` rejected), so a stray ``True``/``0`` cannot reach the
+    thread-count env vars or ``threadpoolctl``.
 
     Parameters
     ----------
@@ -154,7 +176,9 @@ def _effective_blas_cap(num_cpus: int, blas_threads: Optional[int]) -> Optional[
         per-pool override, or ``None`` to defer to the global setting.
     """
     if blas_threads is not None:
-        return blas_threads
+        return _validate_positive_thread_int(
+            blas_threads, "blas_threads override must be a positive int or None"
+        )
     setting = _validated_blas_thread_cap()
     if isinstance(setting, str):  # the "auto" sentinel
         return _auto_blas_cap(num_cpus)
@@ -224,18 +248,10 @@ def _validated_blas_thread_cap() -> "int | str | None":
     threads = getattr(settings, "MULTIPROC_BLAS_THREADS", "auto")
     if threads is None or threads == "auto":
         return threads
-    # bool is an int subclass; reject it explicitly to avoid True -> 1 surprises.
-    if isinstance(threads, bool) or not isinstance(threads, int):
-        raise TypeError(
-            "settings.MULTIPROC_BLAS_THREADS must be 'auto', a positive int, or None, "
-            "got {!r}".format(threads)
-        )
-    if threads < 1:
-        raise ValueError(
-            "settings.MULTIPROC_BLAS_THREADS must be 'auto', a positive int, or None, "
-            "got {}".format(threads)
-        )
-    return threads
+    return _validate_positive_thread_int(
+        threads,
+        "settings.MULTIPROC_BLAS_THREADS must be 'auto', a positive int, or None",
+    )
 
 
 def _import_threadpoolctl() -> Optional[Any]:

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -28,8 +28,9 @@ import scqubits.settings as settings
 
 LOGGER = logging.getLogger(__name__)
 
-# Backend + start method + cpu count of the pool cached in settings.POOL, so reuse
-# does not depend on reading private pool attributes.
+# Backend + start method + cpu count + effective BLAS-thread cap of the pool cached in
+# settings.POOL, so reuse does not depend on reading private pool attributes (and a pool
+# built with a different per-worker BLAS cap is not reused).
 _pool_signature: Optional[tuple] = None
 
 # Environment variables read by the common BLAS/OpenMP backends at numpy import.
@@ -88,6 +89,31 @@ def get_map_method(
         number of worker processes requested by the caller; ``1``
         returns the built-in ``map``, ``> 1`` uses a multiprocessing
         pool of the configured kind.
+    blas_threads:
+        per-worker BLAS/OpenMP thread cap for this pool. ``None`` falls back to
+        ``settings.MULTIPROC_BLAS_THREADS``; an explicit value overrides it for
+        this pool only (used by the auto-parallelization heuristic to scope a cap
+        to a single sweep without mutating global settings).
+    total:
+        number of items the caller will map, used to size the ``imap`` chunks so the
+        parallel path keeps ``pool.map``'s batching. ``None`` uses ``imap``'s default
+        ``chunksize=1`` (finest-grained progress, more dispatch overhead).
+
+    Returns
+    -------
+    A lazy, order-preserving ``map``-style callable. For ``num_cpus == 1`` this is
+    the built-in ``map``; otherwise it is the bound ``imap`` method of a cached or
+    freshly-started pathos or multiprocessing pool (selected by
+    ``settings.MULTIPROC``). ``imap`` (not ``map``) is used so the caller can wrap
+    the returned iterator in ``tqdm`` and get a live progress bar that advances as
+    workers finish, while results are still yielded in input order.
+    """
+    if num_cpus == 1:
+        return map
+
+    # num_cpus > 1 -----------------
+    existing_pool = settings.POOL
+    if existing_pool is not None:
         if _pool_is_reusable(existing_pool, num_cpus, blas_threads):
             return _imap_with_chunksize(existing_pool, num_cpus, total)
         _shutdown_pool(existing_pool)
@@ -97,8 +123,27 @@ def get_map_method(
     return _imap_with_chunksize(settings.POOL, num_cpus, total)
 
 
-def _pool_is_reusable(pool: object, num_cpus: int) -> bool:
-    """Return True if the cached pool matches the requested backend, start method, cpu count.
+def _effective_blas_cap(blas_threads: Optional[int]) -> Optional[int]:
+    """Return the BLAS-thread cap that will actually be applied to a worker pool.
+
+    An explicit ``blas_threads`` override takes precedence; otherwise the configured
+    ``settings.MULTIPROC_BLAS_THREADS`` is used.
+
+    Parameters
+    ----------
+    blas_threads:
+        per-pool override, or ``None`` to defer to the global setting.
+    """
+    if blas_threads is not None:
+        return blas_threads
+    return _validated_blas_thread_cap()
+
+
+def _pool_is_reusable(
+    pool: object, num_cpus: int, blas_threads: Optional[int] = None
+) -> bool:
+    """Return True if the cached pool matches the requested backend, start method,
+    cpu count, and BLAS-thread cap.
 
     Parameters
     ----------
@@ -106,8 +151,17 @@ def _pool_is_reusable(pool: object, num_cpus: int) -> bool:
         the cached pool object (unused; reuse is tracked via ``_pool_signature``).
     num_cpus:
         number of worker processes requested by the caller.
+    blas_threads:
+        per-pool BLAS-thread override, or ``None`` to defer to the global setting.
+        A pool built with a different effective cap is not reused, since the cap is
+        baked into the workers at spawn time.
     """
-    return _pool_signature == (settings.MULTIPROC, _resolve_start_method(), num_cpus)
+    return _pool_signature == (
+        settings.MULTIPROC,
+        _resolve_start_method(),
+        num_cpus,
+        _effective_blas_cap(blas_threads),
+    )
 
 
 def _shutdown_pool(pool: object) -> None:
@@ -257,7 +311,7 @@ def _warn_blas_cap_ineffective(threads: int) -> None:
 
 
 @contextmanager
-def _capped_blas_threads() -> Iterator[None]:
+def _capped_blas_threads(override: Optional[int] = None) -> Iterator[None]:
     """Temporarily cap worker BLAS/OpenMP threads while a pool is created.
 
     Two mechanisms are combined so the cap reaches workers regardless of start
@@ -270,10 +324,16 @@ def _capped_blas_threads() -> Iterator[None]:
       reduced count.
 
     Neither the parent environment nor its thread-pool settings are altered after
-    the block exits. No-op when ``settings.MULTIPROC_BLAS_THREADS`` is ``None``; a
-    warning is emitted when the cap cannot take effect on the current platform.
+    the block exits. No-op when the effective cap is ``None``; a warning is emitted
+    when the cap cannot take effect on the current platform.
+
+    Parameters
+    ----------
+    override:
+        per-pool cap that takes precedence over ``settings.MULTIPROC_BLAS_THREADS``;
+        ``None`` defers to the global setting.
     """
-    threads = _validated_blas_thread_cap()
+    threads = override if override is not None else _validated_blas_thread_cap()
     if threads is None:
         yield
         return
@@ -331,7 +391,51 @@ def _warn_spawn_guard(method: str) -> None:
     _spawn_guard_warned = True
 
 
-def _new_pool(num_cpus: int) -> object:
+def _reconstruct_none() -> None:
+    """Unpickle target for a worker pool (pools are never sent to workers)."""
+    return None
+
+
+def _pool_reduces_to_none(_pool: Any) -> tuple:
+    """Reduce a worker pool to ``None`` for pickling.
+
+    Parameters
+    ----------
+    _pool:
+        the pool being pickled (its identity is irrelevant; it becomes ``None``).
+    """
+    return (_reconstruct_none, ())
+
+
+_pool_reduction_registered = False
+
+
+def _register_pool_pickle_reduction() -> None:
+    """Make worker pools pickle to ``None`` instead of raising.
+
+    With ``dill.settings['recurse'] = True``, pickling a worker task can pull the
+    cached ``settings.POOL`` into the graph (e.g. a ``Circuit``'s lambdified functions
+    reference module globals that reach it). A raw ``multiprocess``/``multiprocessing``
+    pool refuses to be pickled, which would break parallel sweeps of such systems.
+    A worker never needs the parent's pool, so reduce any pool to ``None`` for
+    serialization -- the pathos pool used previously reduced cleanly, so this restores
+    that behavior. Registered once, idempotently.
+    """
+    global _pool_reduction_registered
+    if _pool_reduction_registered:
+        return
+    import copyreg
+
+    for module_name in ("multiprocess.pool", "multiprocessing.pool"):
+        try:
+            pool_cls = importlib.import_module(module_name).Pool
+        except Exception:
+            continue
+        copyreg.pickle(pool_cls, _pool_reduces_to_none)
+    _pool_reduction_registered = True
+
+
+def _new_pool(num_cpus: int, blas_threads: Optional[int] = None) -> object:
     """Start a fresh worker pool of the configured backend and start method.
 
     The pool is created from an explicit process context (see
@@ -348,6 +452,10 @@ def _new_pool(num_cpus: int) -> object:
     ----------
     num_cpus:
         number of worker processes for the new pool.
+    blas_threads:
+        per-pool BLAS-thread override; ``None`` defers to
+        ``settings.MULTIPROC_BLAS_THREADS``. Baked into the pool signature so a
+        differently-capped pool is not reused.
 
     Returns
     -------
@@ -360,9 +468,10 @@ def _new_pool(num_cpus: int) -> object:
                 settings.MULTIPROC
             )
         )
+    _register_pool_pickle_reduction()
     method = _resolve_start_method()
     _warn_spawn_guard(method)
-    with _capped_blas_threads():
+    with _capped_blas_threads(blas_threads):
         if settings.MULTIPROC == "pathos":
             try:
                 import dill
@@ -376,7 +485,12 @@ def _new_pool(num_cpus: int) -> object:
         else:
             import multiprocessing as backend
         pool = backend.get_context(method).Pool(processes=num_cpus)
-    _pool_signature = (settings.MULTIPROC, method, num_cpus)
+    _pool_signature = (
+        settings.MULTIPROC,
+        method,
+        num_cpus,
+        _effective_blas_cap(blas_threads),
+    )
     return pool
 
 

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -42,6 +42,9 @@ _BLAS_THREAD_ENV_VARS = (
 # The "BLAS-thread cap cannot take effect" warning is emitted at most once.
 _blas_cap_ineffective_warned = False
 
+# The "spawn needs a __main__ guard" notice is emitted at most once per process.
+_spawn_guard_warned = False
+
 
 def get_map_method(num_cpus: int) -> Callable:
     """Selects the correct `.map` method depending on the specified number of desired
@@ -286,6 +289,39 @@ def _capped_blas_threads() -> Iterator[None]:
                 os.environ[var] = original
 
 
+def _warn_spawn_guard(method: str) -> None:
+    """Warn (once) that spawn/forkserver workers require a ``__main__`` guard.
+
+    With ``spawn``/``forkserver`` (the default on macOS and Windows), worker processes
+    re-import the program's entry module, so a plain script that triggers parallel
+    computation must guard its entry point with ``if __name__ == "__main__":`` or it
+    raises a ``RuntimeError`` when the workers start. Jupyter/IPython need no guard. This
+    proactive notice pre-empts that confusing failure; it is a no-op under fork and under
+    IPython.
+
+    Parameters
+    ----------
+    method:
+        the start method the pool will use.
+    """
+    global _spawn_guard_warned
+    if _spawn_guard_warned or method not in ("spawn", "forkserver"):
+        return
+    if getattr(settings, "IN_IPYTHON", False):
+        return  # interactive shells provide an importable entry point already
+    warnings.warn(
+        "scqubits is starting worker processes with the {!r} start method (the safe "
+        "default on macOS, where fork-after-threads is unsafe). If you are running a "
+        "plain Python script, its entry point must be guarded:\n\n"
+        '    if __name__ == "__main__":\n'
+        "        ...   # code that triggers num_cpus > 1\n\n"
+        "Jupyter/IPython need no guard. To use fork instead, set "
+        "scqubits.settings.MULTIPROC_START_METHOD = 'fork'.".format(method),
+        stacklevel=3,
+    )
+    _spawn_guard_warned = True
+
+
 def _new_pool(num_cpus: int) -> object:
     """Start a fresh worker pool of the configured backend and start method.
 
@@ -316,6 +352,7 @@ def _new_pool(num_cpus: int) -> object:
             )
         )
     method = _resolve_start_method()
+    _warn_spawn_guard(method)
     with _capped_blas_threads():
         if settings.MULTIPROC == "pathos":
             try:

--- a/scqubits/utils/cpu_switch.py
+++ b/scqubits/utils/cpu_switch.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import atexit
+import functools
 import importlib
 import logging
 import os
@@ -46,7 +47,32 @@ _blas_cap_ineffective_warned = False
 _spawn_guard_warned = False
 
 
-def get_map_method(num_cpus: int) -> Callable:
+def _imap_with_chunksize(pool: Any, num_cpus: int, total: Optional[int]) -> Callable:
+    """Return ``pool.imap`` bound with a ``map``-style chunksize.
+
+    Batching the worker dispatch (rather than ``imap``'s default ``chunksize=1``)
+    recovers ``pool.map``'s throughput, while ``imap`` still yields results one at a
+    time so a wrapping ``tqdm`` advances per grid point. The chunksize matches the
+    one ``pool.map`` computes (``ceil(total / (4 * num_cpus))``).
+
+    Parameters
+    ----------
+    pool:
+        the worker pool whose ``imap`` is used.
+    num_cpus:
+        worker count, used to size the chunks.
+    total:
+        number of items to be mapped; ``None`` leaves ``chunksize`` at the default.
+    """
+    if total is None:
+        return pool.imap
+    chunksize = max(1, -(-int(total) // (4 * num_cpus)))
+    return functools.partial(pool.imap, chunksize=chunksize)
+
+
+def get_map_method(
+    num_cpus: int, blas_threads: Optional[int] = None, total: Optional[int] = None
+) -> Callable:
     """Selects the correct `.map` method depending on the specified number of desired
     cores. If num_cpus>1, a multiprocessing/pathos pool is used.
 
@@ -62,27 +88,13 @@ def get_map_method(num_cpus: int) -> Callable:
         number of worker processes requested by the caller; ``1``
         returns the built-in ``map``, ``> 1`` uses a multiprocessing
         pool of the configured kind.
-
-    Returns
-    -------
-    A ``.map``-style callable to be used by the caller.  For
-    ``num_cpus == 1`` this is the built-in ``map``; otherwise it is
-    the bound ``map`` method of a cached or freshly-started pathos or
-    multiprocessing pool (selected by ``settings.MULTIPROC``).
-    """
-    if num_cpus == 1:
-        return map
-
-    # num_cpus > 1 -----------------
-    existing_pool = settings.POOL
-    if existing_pool is not None:
-        if _pool_is_reusable(existing_pool, num_cpus):
-            return existing_pool.map
+        if _pool_is_reusable(existing_pool, num_cpus, blas_threads):
+            return _imap_with_chunksize(existing_pool, num_cpus, total)
         _shutdown_pool(existing_pool)
         settings.POOL = None
 
-    settings.POOL = _new_pool(num_cpus)
-    return settings.POOL.map
+    settings.POOL = _new_pool(num_cpus, blas_threads)
+    return _imap_with_chunksize(settings.POOL, num_cpus, total)
 
 
 def _pool_is_reusable(pool: object, num_cpus: int) -> bool:

--- a/scqubits/utils/misc.py
+++ b/scqubits/utils/misc.py
@@ -29,15 +29,6 @@ import scipy as sp
 
 from matplotlib import get_backend as get_matplotlib_backend
 
-import scqubits.settings
-
-from scqubits.settings import IN_IPYTHON
-
-if IN_IPYTHON:
-    from tqdm.notebook import tqdm
-else:
-    from tqdm import tqdm  # type: ignore[assignment]
-
 
 def process_which(which: int | Iterable[int], max_index: int) -> list[int]:
     """Processes different ways of specifying the selection of  wanted
@@ -88,36 +79,6 @@ def make_bare_labels(subsystem_count: int, *args) -> tuple[int, ...]:
 def drop_private_keys(full_dict: dict[str, Any]) -> dict[str, Any]:
     """Filter for entries in the full dictionary that have numerical values."""
     return {key: value for key, value in full_dict.items() if key[0] != "_"}
-
-
-class InfoBar:
-    """Static "progress" bar used whenever multiprocessing is involved.
-
-    Parameters
-    ----------
-    desc:
-        Description text to be displayed on the static information bar.
-    num_cpus:
-        Number of CPUS/cores employed in underlying calculation.
-    """
-
-    def __init__(self, desc: str, num_cpus: int) -> None:
-        self.desc = desc
-        self.num_cpus = num_cpus
-        self.tqdm_bar: Any = None
-
-    def __enter__(self) -> None:
-        self.tqdm_bar = tqdm(
-            total=0,
-            disable=(self.num_cpus == 1) or scqubits.settings.PROGRESSBAR_DISABLED,
-            leave=False,
-            desc=self.desc,
-            bar_format="{desc}",
-        )
-
-    def __exit__(self, *args) -> None:
-        if self.tqdm_bar:
-            self.tqdm_bar.close()
 
 
 class Required:

--- a/tools/BENCHMARKS.md
+++ b/tools/BENCHMARKS.md
@@ -1,0 +1,87 @@
+# Multiprocessing benchmarks
+
+`benchmark_multiprocessing.py` is a standalone developer tool (not run by pytest)
+for measuring the parallelized code paths in scqubits and tracking the effect of
+future optimizations against a baseline.
+
+## Running
+
+```bash
+# full baseline across worker counts, written to tools/benchmark_results/
+python tools/benchmark_multiprocessing.py --scenario all --num-cpus 1,2,4 --repeats 3 --json
+
+# single scenario / heavier per-task workload
+python tools/benchmark_multiprocessing.py --scenario sweep --grid 64 --evals-count 30
+
+# correctness guard (compares the 11x3 sweep against test reference evals)
+python tools/benchmark_multiprocessing.py --scenario qubit --verify
+```
+
+Scenarios: `sweep` (`ParameterSweep.run`), `hspace`
+(`HilbertSpace.get_spectrum_vs_paramvals`), `qubit`
+(`TunableTransmon.get_spectrum_vs_paramvals`). The benchmarked system mirrors
+`scqubits/tests/test_parametersweep.py`.
+
+The harness instruments two known overhead sources without editing library code
+(process-local monkeypatch): `map_calls` / `pool_spawn(s)` = how many pools are
+spawned per run and the time spent constructing them; plus the dill payload size
+of the `HilbertSpace` and the `update_hilbertspace` closure shipped to workers.
+
+## Baseline (2026-05-30)
+
+Windows 11, 20 logical cores, `MULTIPROC=pathos`, scqubits 4.3.1, default test
+system (two TunableTransmons + Oscillator), 11x3 grid, evals_count=20, repeats=3.
+Median wall time in seconds:
+
+| scenario | num_cpus=1 | num_cpus=2 | num_cpus=4 | map_calls |
+|----------|-----------:|-----------:|-----------:|----------:|
+| sweep    | 0.127      | 2.509      | 2.729      | 4         |
+| hspace   | 0.033      | 2.420      | 2.539      | 1         |
+| qubit    | 0.028      | 2.384      | 2.406      | 1         |
+
+dill payload: HilbertSpace ~2.0 KB, update closure ~1.4 KB.
+
+### Observations
+1. **For this small system, multiprocessing is net-negative in every scenario.**
+   Per-task compute is sub-millisecond to a few ms, while there is a ~2.4 s floor
+   dominated by Windows spawn-based worker startup and per-task dill IPC. To see
+   any MP benefit you must raise the per-task cost (larger `ncut` /
+   `truncated_dim` / `evals_count`, or more grid points); the harness is designed
+   to find that crossover.
+2. **A fresh pool is spawned for every parallel phase and never reused.** One
+   `ParameterSweep.run()` reports `map_calls=4` (one bare-spectrum sweep per
+   subsystem, plus the dressed sweep). `cpu_switch.get_map_method` always builds
+   a new `pathos.ProcessPool` and overwrites `settings.POOL`, ignoring the cached
+   pool and never terminating the orphaned one.
+
+## Pool-reuse optimization (implemented)
+
+`cpu_switch.get_map_method` now caches the pool in `settings.POOL` and reuses it
+when a later call requests the same backend and worker count, instead of building
+a fresh pool every time; a stale pool (different `num_cpus`) is shut down first.
+This realizes the intent already noted at `settings.py` ("store processing pool
+once generated"). Public `num_cpus` API unchanged; `dill`/pathos retained.
+
+Before vs after, heavy profile, sweep, grid=8 (24 points), repeats=2, this box.
+Median wall time (s) and pools constructed per `ParameterSweep.run()`:
+
+| num_cpus | before (s) | after (s) | before speedup | after speedup | pools/run |
+|---------:|-----------:|----------:|---------------:|--------------:|----------:|
+| 1        | 18.75      | 19.16     | 1.00           | 1.00          | 0         |
+| 2        | 13.28      | 12.82     | 1.41           | 1.49          | 4 -> 1    |
+| 4        | 9.66       | 8.80      | 1.94           | 2.18          | 4 -> 1    |
+
+**Finding:** pools constructed per run drop 4 -> 1 and the 4-core run is ~9%
+faster, but the gain is modest. pathos already caches pools internally, so the
+old code was *not* paying a full 4x worker-spawn cost; explicit reuse mainly
+removes pool-object/cache churn and stops orphaning pools. The larger remaining
+costs are the diagonalizations themselves and per-task serialization. Verified
+no regression: `pytest test_parametersweep.py test_transmon.py --num_cpus 2`.
+
+## Remaining optimization targets
+- **Chunking** — the `.map` calls pass no `chunksize` (`cpu_switch.py`).
+- **Per-task serialization** — avoid re-pickling the `HilbertSpace`/subsystem for
+  every task (`scqubits/core/param_sweep.py`); likely the biggest lever here.
+
+Constraint: `dill` is required for Windows spawn-based multiprocessing and must
+not be removed; optimizations must preserve the public `num_cpus` API.

--- a/tools/benchmark_multiprocessing.py
+++ b/tools/benchmark_multiprocessing.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python
+# benchmark_multiprocessing.py
+#
+# This file is part of scqubits: a Python package for superconducting qubits,
+# Quantum 5, 583 (2021). https://quantum-journal.org/papers/q-2021-11-17-583/
+#
+#    Copyright (c) 2019 and later, Jens Koch and Peter Groszkowski
+#    All rights reserved.
+#
+#    This source code is licensed under the BSD-style license found in the
+#    LICENSE file in the root directory of this source tree.
+############################################################################
+"""Baseline benchmark harness for scqubits multiprocessing.
+
+Standalone developer tool (not collected by pytest). It measures the wall time
+of the parallelized code paths across worker counts and instruments two known
+overhead sources so future optimizations can be compared against a baseline:
+
+* pool lifecycle: how many times ``cpu_switch.get_map_method`` is invoked per
+  run (``map_calls``), how many real pools are actually constructed
+  (``pools_created`` -- these differ once pool reuse lands), and the wall time
+  spent constructing pools;
+* per-task serialization payload: the dill-pickled size of the ``HilbertSpace``
+  and of the user ``update_hilbertspace`` closure shipped to workers.
+
+The harness does NOT modify library code; instrumentation is done by monkey-
+patching within this process only.
+
+Scenarios
+---------
+sweep   ``ParameterSweep.run()`` over a 2-D flux x ng grid (bare + dressed).
+hspace  ``HilbertSpace.get_spectrum_vs_paramvals`` (composite 1-D scan).
+qubit   ``TunableTransmon.get_spectrum_vs_paramvals`` (single-qubit 1-D scan).
+
+Profiles
+--------
+light   matches scqubits/tests/test_parametersweep.py (tiny; --verify uses it).
+heavy   enlarged truncated dims / ncut so multiprocessing can actually pay off.
+
+Examples
+--------
+    python tools/benchmark_multiprocessing.py --scenario all --num-cpus 1,2,4
+    python tools/benchmark_multiprocessing.py --profile heavy --grid 32 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import os
+import platform
+import statistics
+import sys
+import time
+
+from typing import Any, Callable
+
+import numpy as np
+
+# Ensure the in-repo scqubits source is importable when this script is run
+# directly: `python tools/benchmark_multiprocessing.py` puts tools/ on
+# sys.path[0], not the repo root.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import scqubits as scq
+import scqubits.core.qubit_base as qubit_base
+import scqubits.settings as settings
+import scqubits.utils.cpu_switch as cpu_switch
+
+
+# Reference eigenvalues for sweep["evals"][1, 1] with the "light" system below
+# and evals_count=20. Copied from scqubits/tests/test_parametersweep.py so the
+# benchmarked computation can be sanity-checked for correctness.
+_REFERENCE_EVALS_11 = np.array(
+    [
+        -38.24067872, -34.80636811, -33.70287551, -31.50027076, -31.23467726,
+        -30.28547786, -29.16544659, -27.80039104, -27.08317259, -26.69778263,
+        -25.76389721, -24.59864846, -24.49435409, -24.43639473, -23.2803766,
+        -22.63621727, -22.16084701, -21.00224623, -21.00053542, -20.07811164,
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------
+# System under test (mirrors tests/test_parametersweep.py initialize())
+# --------------------------------------------------------------------------------------
+# Workload profiles. "light" matches tests/test_parametersweep.py exactly (used
+# by the --verify correctness guard). "heavy" enlarges the truncated dimensions
+# (and ncut) so the dressed diagonalization is costly enough for multiprocessing
+# to pay off, locating the regime where parallelism actually helps.
+PROFILES = {
+    "light": {"ncut1": 40, "ncut2": 30, "dim1": 3, "dim2": 3, "res_dim": 4},
+    "heavy": {"ncut1": 110, "ncut2": 110, "dim1": 8, "dim2": 8, "res_dim": 10},
+}
+PROFILE = "light"
+
+
+def _build_components() -> tuple[Any, Any, Any]:
+    """Return the two tunable transmons and the oscillator for the active profile."""
+    p = PROFILES[PROFILE]
+    tmon1 = scq.TunableTransmon(
+        EJmax=40.0, EC=0.2, d=0.1, flux=0.0, ng=0.3,
+        ncut=p["ncut1"], truncated_dim=p["dim1"],
+    )
+    tmon2 = scq.TunableTransmon(
+        EJmax=15.0, EC=0.15, d=0.2, flux=0.0, ng=0.0,
+        ncut=p["ncut2"], truncated_dim=p["dim2"],
+    )
+    resonator = scq.Oscillator(E_osc=4.5, truncated_dim=p["res_dim"])
+    return tmon1, tmon2, resonator
+
+
+def _build_hilbertspace(tmon1: Any, tmon2: Any, resonator: Any) -> Any:
+    """Assemble the coupled HilbertSpace used throughout the benchmark."""
+    hilbertspace = scq.HilbertSpace([tmon1, tmon2, resonator])
+    hilbertspace.add_interaction(
+        g_strength=0.1, op1=tmon1.n_operator, op2=resonator.creation_operator, add_hc=True
+    )
+    hilbertspace.add_interaction(
+        g_strength=0.2, op1=tmon2.n_operator, op2=resonator.creation_operator, add_hc=True
+    )
+    return hilbertspace
+
+
+def _build_sweep(flux_count: int, evals_count: int, num_cpus: int) -> Any:
+    """Build a (non-autorun) 2-D ParameterSweep over flux x ng."""
+    tmon1, tmon2, resonator = _build_components()
+    hilbertspace = _build_hilbertspace(tmon1, tmon2, resonator)
+    flux_vals = np.linspace(0.0, 2.0, flux_count)
+    ng_vals = np.linspace(-0.5, 0.5, 3)
+    area_ratio = 1.2
+
+    def update_hilbertspace(flux: float, ng: float) -> None:
+        tmon1.flux = flux
+        tmon2.flux = area_ratio * flux
+        tmon2.ng = ng
+
+    return scq.ParameterSweep(
+        hilbertspace=hilbertspace,
+        paramvals_by_name={"flux": flux_vals, "ng": ng_vals},
+        update_hilbertspace=update_hilbertspace,
+        evals_count=evals_count,
+        subsys_update_info={"flux": [tmon1, tmon2], "ng": [tmon2]},
+        num_cpus=num_cpus,
+        autorun=False,
+    )
+
+
+def _build_hspace_scan(flux_count: int) -> tuple[Any, np.ndarray, Callable]:
+    """Build the composite-system 1-D scan inputs (HilbertSpace path)."""
+    tmon1, tmon2, resonator = _build_components()
+    hilbertspace = _build_hilbertspace(tmon1, tmon2, resonator)
+    flux_vals = np.linspace(0.0, 2.0, flux_count)
+
+    def update_hilbertspace(flux: float) -> None:
+        tmon1.flux = flux
+        tmon2.flux = 1.2 * flux
+
+    return hilbertspace, flux_vals, update_hilbertspace
+
+
+# --------------------------------------------------------------------------------------
+# Instrumentation (process-local monkeypatch of get_map_method + pool factory)
+# --------------------------------------------------------------------------------------
+class _MapInstrument:
+    """Counts map-method calls, real pool constructions, and pool-build time."""
+
+    def __init__(self) -> None:
+        self._orig = cpu_switch.get_map_method
+        self._pathos_pools: Any = None
+        self._orig_pool_cls: Any = None
+        self.calls = 0
+        self.pool_spawn_s = 0.0
+        self.pools_created = 0
+
+    def _wrapped(self, num_cpus: int) -> Callable:
+        self.calls += 1
+        start = time.perf_counter()
+        method = self._orig(num_cpus)
+        self.pool_spawn_s += time.perf_counter() - start
+        return method
+
+    def __enter__(self) -> "_MapInstrument":
+        cpu_switch.get_map_method = self._wrapped
+        qubit_base.get_map_method = self._wrapped  # qubit_base imported it by name
+        try:
+            import pathos.pools as pathos_pools
+
+            self._pathos_pools = pathos_pools
+            self._orig_pool_cls = pathos_pools.ProcessPool
+            instrument = self
+
+            def _counting_pool(*args: Any, **kwargs: Any) -> Any:
+                instrument.pools_created += 1
+                return instrument._orig_pool_cls(*args, **kwargs)
+
+            pathos_pools.ProcessPool = _counting_pool
+        except Exception:
+            self._pathos_pools = None
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        cpu_switch.get_map_method = self._orig
+        qubit_base.get_map_method = self._orig
+        if self._pathos_pools is not None and self._orig_pool_cls is not None:
+            self._pathos_pools.ProcessPool = self._orig_pool_cls
+
+    def reset(self) -> None:
+        self.calls = 0
+        self.pool_spawn_s = 0.0
+        self.pools_created = 0
+
+
+def _cleanup_pool() -> None:
+    """Terminate and forget any global pool so the next config spawns fresh."""
+    pool = settings.POOL
+    if pool is not None:
+        for method_name in ("terminate", "close", "clear"):
+            try:
+                getattr(pool, method_name)()
+            except Exception:
+                pass
+    settings.POOL = None
+
+
+# --------------------------------------------------------------------------------------
+# Timing
+# --------------------------------------------------------------------------------------
+def _time_callable(
+    make_and_run: Callable[[], Any], repeats: int, instrument: _MapInstrument
+) -> dict[str, float]:
+    """Warm up once, then time `repeats` runs; return min/median + instrument data."""
+    _cleanup_pool()
+    make_and_run()  # warm-up (pays first-spawn / import cost)
+
+    durations: list[float] = []
+    last_calls = 0
+    last_spawn = 0.0
+    last_pools = 0
+    for _ in range(repeats):
+        _cleanup_pool()
+        instrument.reset()
+        start = time.perf_counter()
+        make_and_run()
+        durations.append(time.perf_counter() - start)
+        last_calls = instrument.calls
+        last_spawn = instrument.pool_spawn_s
+        last_pools = instrument.pools_created
+    _cleanup_pool()
+
+    return {
+        "wall_min_s": min(durations),
+        "wall_median_s": statistics.median(durations),
+        "map_calls": last_calls,
+        "pools_created": last_pools,
+        "pool_spawn_s": last_spawn,
+    }
+
+
+def _runner_for(scenario: str, args: argparse.Namespace, num_cpus: int) -> Callable[[], Any]:
+    """Return a zero-arg callable that builds + runs one scenario at `num_cpus`."""
+    if scenario == "sweep":
+        def run() -> Any:
+            sweep = _build_sweep(args.grid, args.evals_count, num_cpus)
+            sweep.run()
+            return sweep
+        return run
+    if scenario == "hspace":
+        def run() -> Any:
+            hspace, flux_vals, update = _build_hspace_scan(args.grid)
+            return hspace.get_spectrum_vs_paramvals(
+                flux_vals, update, evals_count=args.evals_count, num_cpus=num_cpus
+            )
+        return run
+    if scenario == "qubit":
+        def run() -> Any:
+            tmon, _, _ = _build_components()
+            flux_vals = np.linspace(0.0, 2.0, max(args.grid, 50))
+            return tmon.get_spectrum_vs_paramvals(
+                "flux", flux_vals, evals_count=args.evals_count, num_cpus=num_cpus
+            )
+        return run
+    raise ValueError(f"unknown scenario: {scenario}")
+
+
+# --------------------------------------------------------------------------------------
+# Serialization payload measurement
+# --------------------------------------------------------------------------------------
+def _measure_serialization(args: argparse.Namespace) -> dict[str, Any]:
+    """Quantify the dill payload of the HilbertSpace and the update closure."""
+    try:
+        import dill
+    except ImportError:
+        return {"available": False}
+
+    tmon1, tmon2, resonator = _build_components()
+    hilbertspace = _build_hilbertspace(tmon1, tmon2, resonator)
+
+    def update_hilbertspace(flux: float, ng: float) -> None:
+        tmon1.flux = flux
+        tmon2.flux = 1.2 * flux
+        tmon2.ng = ng
+
+    dill.settings["recurse"] = True
+    start = time.perf_counter()
+    hs_blob = dill.dumps(hilbertspace)
+    hs_dumps_s = time.perf_counter() - start
+    update_blob = dill.dumps(update_hilbertspace)
+
+    return {
+        "available": True,
+        "hilbertspace_bytes": len(hs_blob),
+        "hilbertspace_dumps_s": hs_dumps_s,
+        "update_func_bytes": len(update_blob),
+    }
+
+
+# --------------------------------------------------------------------------------------
+# Correctness guard
+# --------------------------------------------------------------------------------------
+def _verify(num_cpus: int) -> bool:
+    """Run the canonical light 11x3 sweep and compare evals[1, 1] to the reference."""
+    global PROFILE
+    saved_profile = PROFILE
+    PROFILE = "light"  # reference evals are only valid for the light system
+    try:
+        sweep = _build_sweep(flux_count=11, evals_count=20, num_cpus=num_cpus)
+        sweep.run()
+        calculated = np.asarray(sweep["evals"][1, 1])
+    finally:
+        PROFILE = saved_profile
+    ok = bool(np.allclose(_REFERENCE_EVALS_11, calculated))
+    print(f"[verify] sweep evals[1,1] vs reference (num_cpus={num_cpus}): "
+          f"{'PASS' if ok else 'FAIL'}")
+    return ok
+
+
+# --------------------------------------------------------------------------------------
+# Orchestration / reporting
+# --------------------------------------------------------------------------------------
+def _parse_num_cpus(raw: str, available: bool) -> list[int]:
+    requested = sorted({int(token) for token in raw.split(",") if token.strip()})
+    cap = os.cpu_count() or 1
+    capped = [n for n in requested if 1 <= n <= cap]
+    if not capped:
+        capped = [1]
+    if not available:
+        # pathos/dill missing: only the serial path is runnable
+        capped = [1]
+        print("[warn] pathos/dill unavailable; restricting to num_cpus=1.")
+    return capped
+
+
+def _print_table(scenario: str, rows: list[dict[str, Any]]) -> None:
+    print(f"\n=== scenario: {scenario} ===")
+    header = (
+        f"{'cpus':>4}  {'min(s)':>9}  {'median(s)':>10}  {'speedup':>8}  "
+        f"{'eff':>6}  {'map_calls':>9}  {'pools':>6}  {'pool_spawn(s)':>13}"
+    )
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        print(
+            f"{row['num_cpus']:>4}  {row['wall_min_s']:>9.3f}  "
+            f"{row['wall_median_s']:>10.3f}  {row['speedup_vs_1']:>8.2f}  "
+            f"{row['efficiency']:>6.2f}  {row['map_calls']:>9}  "
+            f"{row['pools_created']:>6}  {row['pool_spawn_s']:>13.3f}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    global PROFILE
+
+    parser = argparse.ArgumentParser(description="scqubits multiprocessing benchmark.")
+    parser.add_argument("--scenario", default="all",
+                        choices=["sweep", "hspace", "qubit", "all"])
+    parser.add_argument("--profile", default="light", choices=["light", "heavy"],
+                        help="workload size (heavy => MP can pay off)")
+    parser.add_argument("--num-cpus", default="1,2,4",
+                        help="comma-separated worker counts, e.g. '1,2,4'")
+    parser.add_argument("--grid", type=int, default=11,
+                        help="number of flux points (ng axis fixed at 3 for sweep)")
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--evals-count", type=int, default=20)
+    parser.add_argument("--verify", action="store_true",
+                        help="run the light 11x3 correctness guard against reference evals")
+    parser.add_argument("--json", nargs="?", const="<auto>", default=None,
+                        help="write results JSON (optional path; default under "
+                             "tools/benchmark_results/)")
+    args = parser.parse_args(argv)
+
+    PROFILE = args.profile
+
+    try:
+        import dill  # noqa: F401
+        import pathos  # noqa: F401
+        backend_available = True
+    except ImportError:
+        backend_available = False
+
+    # Quiet the per-call tqdm progress bars if the installed version exposes a switch.
+    for flag in ("PROGRESSBAR_DISABLED", "DISABLE_PROGRESSBAR"):
+        if hasattr(settings, flag):
+            setattr(settings, flag, True)
+
+    num_cpus_list = _parse_num_cpus(args.num_cpus, backend_available)
+    scenarios = ["sweep", "hspace", "qubit"] if args.scenario == "all" else [args.scenario]
+
+    print(f"platform={platform.platform()}  cpu_count={os.cpu_count()}  "
+          f"MULTIPROC={settings.MULTIPROC}  scqubits={scq.__version__}")
+    print(f"profile={PROFILE}  num_cpus={num_cpus_list}  grid={args.grid}  "
+          f"repeats={args.repeats}  evals_count={args.evals_count}")
+
+    if args.verify:
+        _verify(num_cpus=1)
+
+    all_results: list[dict[str, Any]] = []
+    with _MapInstrument() as instrument:
+        for scenario in scenarios:
+            rows: list[dict[str, Any]] = []
+            baseline_median: float | None = None
+            for num_cpus in num_cpus_list:
+                timing = _time_callable(
+                    _runner_for(scenario, args, num_cpus), args.repeats, instrument
+                )
+                if baseline_median is None:
+                    baseline_median = timing["wall_median_s"]
+                speedup = baseline_median / timing["wall_median_s"]
+                row = {
+                    "scenario": scenario,
+                    "profile": PROFILE,
+                    "num_cpus": num_cpus,
+                    "grid_points": args.grid * 3 if scenario == "sweep" else max(args.grid, 50),
+                    "evals_count": args.evals_count,
+                    "repeats": args.repeats,
+                    "speedup_vs_1": speedup,
+                    "efficiency": speedup / num_cpus,
+                    **timing,
+                }
+                rows.append(row)
+                all_results.append(row)
+            _print_table(scenario, rows)
+
+    serialization = _measure_serialization(args)
+    print("\n=== serialization payload (dill) ===")
+    if serialization.get("available"):
+        print(f"HilbertSpace: {serialization['hilbertspace_bytes']:,} bytes  "
+              f"(dumps {serialization['hilbertspace_dumps_s'] * 1e3:.1f} ms)")
+        print(f"update closure: {serialization['update_func_bytes']:,} bytes")
+    else:
+        print("dill unavailable; skipped.")
+
+    if args.json is not None:
+        report = {
+            "meta": {
+                "timestamp": datetime.datetime.now().isoformat(timespec="seconds"),
+                "platform": platform.platform(),
+                "cpu_count": os.cpu_count(),
+                "multiproc": settings.MULTIPROC,
+                "profile": PROFILE,
+                "scqubits_version": scq.__version__,
+            },
+            "results": all_results,
+            "serialization": serialization,
+        }
+        import json
+
+        results_dir = os.path.join(os.path.dirname(__file__), "benchmark_results")
+        os.makedirs(results_dir, exist_ok=True)
+        if args.json == "<auto>":
+            stamp = report["meta"]["timestamp"].replace(":", "").replace("-", "")
+            path = os.path.join(results_dir, f"{PROFILE}_{stamp}.json")
+        else:
+            path = args.json
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2)
+        print(f"\nwrote results to {path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/benchmark_multiprocessing.py
+++ b/tools/benchmark_multiprocessing.py
@@ -200,43 +200,37 @@ class _MapInstrument:
 
     def __init__(self) -> None:
         self._orig = cpu_switch.get_map_method
-        self._pathos_pools: Any = None
-        self._orig_pool_cls: Any = None
+        self._orig_new_pool = cpu_switch._new_pool
         self.calls = 0
         self.pool_spawn_s = 0.0
         self.pools_created = 0
 
-    def _wrapped(self, num_cpus: int) -> Callable:
+    def _wrapped(self, num_cpus: int, *args: Any, **kwargs: Any) -> Callable:
+        # forward total=/blas_threads= so the wrapper matches get_map_method's signature
         self.calls += 1
         start = time.perf_counter()
-        method = self._orig(num_cpus)
+        method = self._orig(num_cpus, *args, **kwargs)
         self.pool_spawn_s += time.perf_counter() - start
         return method
+
+    def _counting_new_pool(self, *args: Any, **kwargs: Any) -> Any:
+        self.pools_created += 1
+        return self._orig_new_pool(*args, **kwargs)
 
     def __enter__(self) -> "_MapInstrument":
         cpu_switch.get_map_method = self._wrapped
         qubit_base.get_map_method = self._wrapped  # qubit_base imported it by name
-        try:
-            import pathos.pools as pathos_pools
-
-            self._pathos_pools = pathos_pools
-            self._orig_pool_cls = pathos_pools.ProcessPool
-            instrument = self
-
-            def _counting_pool(*args: Any, **kwargs: Any) -> Any:
-                instrument.pools_created += 1
-                return instrument._orig_pool_cls(*args, **kwargs)
-
-            pathos_pools.ProcessPool = _counting_pool
-        except Exception:
-            self._pathos_pools = None
+        # _new_pool is the single point in cpu_switch where a real pool is built
+        # (it is skipped on reuse), so counting its calls is the true construction
+        # count -- and unlike patching the Pool class, it does not disturb the
+        # multiprocessing internals that reference Pool by module-global name.
+        cpu_switch._new_pool = self._counting_new_pool
         return self
 
     def __exit__(self, *exc: Any) -> None:
         cpu_switch.get_map_method = self._orig
         qubit_base.get_map_method = self._orig
-        if self._pathos_pools is not None and self._orig_pool_cls is not None:
-            self._pathos_pools.ProcessPool = self._orig_pool_cls
+        cpu_switch._new_pool = self._orig_new_pool
 
     def reset(self) -> None:
         self.calls = 0

--- a/tools/benchmark_multiprocessing.py
+++ b/tools/benchmark_multiprocessing.py
@@ -69,16 +69,31 @@ import scqubits.core.qubit_base as qubit_base
 import scqubits.settings as settings
 import scqubits.utils.cpu_switch as cpu_switch
 
-
 # Reference eigenvalues for sweep["evals"][1, 1] with the "light" system below
 # and evals_count=20. Copied from scqubits/tests/test_parametersweep.py so the
 # benchmarked computation can be sanity-checked for correctness.
 _REFERENCE_EVALS_11 = np.array(
     [
-        -38.24067872, -34.80636811, -33.70287551, -31.50027076, -31.23467726,
-        -30.28547786, -29.16544659, -27.80039104, -27.08317259, -26.69778263,
-        -25.76389721, -24.59864846, -24.49435409, -24.43639473, -23.2803766,
-        -22.63621727, -22.16084701, -21.00224623, -21.00053542, -20.07811164,
+        -38.24067872,
+        -34.80636811,
+        -33.70287551,
+        -31.50027076,
+        -31.23467726,
+        -30.28547786,
+        -29.16544659,
+        -27.80039104,
+        -27.08317259,
+        -26.69778263,
+        -25.76389721,
+        -24.59864846,
+        -24.49435409,
+        -24.43639473,
+        -23.2803766,
+        -22.63621727,
+        -22.16084701,
+        -21.00224623,
+        -21.00053542,
+        -20.07811164,
     ]
 )
 
@@ -101,12 +116,22 @@ def _build_components() -> tuple[Any, Any, Any]:
     """Return the two tunable transmons and the oscillator for the active profile."""
     p = PROFILES[PROFILE]
     tmon1 = scq.TunableTransmon(
-        EJmax=40.0, EC=0.2, d=0.1, flux=0.0, ng=0.3,
-        ncut=p["ncut1"], truncated_dim=p["dim1"],
+        EJmax=40.0,
+        EC=0.2,
+        d=0.1,
+        flux=0.0,
+        ng=0.3,
+        ncut=p["ncut1"],
+        truncated_dim=p["dim1"],
     )
     tmon2 = scq.TunableTransmon(
-        EJmax=15.0, EC=0.15, d=0.2, flux=0.0, ng=0.0,
-        ncut=p["ncut2"], truncated_dim=p["dim2"],
+        EJmax=15.0,
+        EC=0.15,
+        d=0.2,
+        flux=0.0,
+        ng=0.0,
+        ncut=p["ncut2"],
+        truncated_dim=p["dim2"],
     )
     resonator = scq.Oscillator(E_osc=4.5, truncated_dim=p["res_dim"])
     return tmon1, tmon2, resonator
@@ -116,10 +141,16 @@ def _build_hilbertspace(tmon1: Any, tmon2: Any, resonator: Any) -> Any:
     """Assemble the coupled HilbertSpace used throughout the benchmark."""
     hilbertspace = scq.HilbertSpace([tmon1, tmon2, resonator])
     hilbertspace.add_interaction(
-        g_strength=0.1, op1=tmon1.n_operator, op2=resonator.creation_operator, add_hc=True
+        g_strength=0.1,
+        op1=tmon1.n_operator,
+        op2=resonator.creation_operator,
+        add_hc=True,
     )
     hilbertspace.add_interaction(
-        g_strength=0.2, op1=tmon2.n_operator, op2=resonator.creation_operator, add_hc=True
+        g_strength=0.2,
+        op1=tmon2.n_operator,
+        op2=resonator.creation_operator,
+        add_hc=True,
     )
     return hilbertspace
 
@@ -259,28 +290,36 @@ def _time_callable(
     }
 
 
-def _runner_for(scenario: str, args: argparse.Namespace, num_cpus: int) -> Callable[[], Any]:
+def _runner_for(
+    scenario: str, args: argparse.Namespace, num_cpus: int
+) -> Callable[[], Any]:
     """Return a zero-arg callable that builds + runs one scenario at `num_cpus`."""
     if scenario == "sweep":
+
         def run() -> Any:
             sweep = _build_sweep(args.grid, args.evals_count, num_cpus)
             sweep.run()
             return sweep
+
         return run
     if scenario == "hspace":
+
         def run() -> Any:
             hspace, flux_vals, update = _build_hspace_scan(args.grid)
             return hspace.get_spectrum_vs_paramvals(
                 flux_vals, update, evals_count=args.evals_count, num_cpus=num_cpus
             )
+
         return run
     if scenario == "qubit":
+
         def run() -> Any:
             tmon, _, _ = _build_components()
             flux_vals = np.linspace(0.0, 2.0, max(args.grid, 50))
             return tmon.get_spectrum_vs_paramvals(
                 "flux", flux_vals, evals_count=args.evals_count, num_cpus=num_cpus
             )
+
         return run
     raise ValueError(f"unknown scenario: {scenario}")
 
@@ -332,8 +371,10 @@ def _verify(num_cpus: int) -> bool:
     finally:
         PROFILE = saved_profile
     ok = bool(np.allclose(_REFERENCE_EVALS_11, calculated))
-    print(f"[verify] sweep evals[1,1] vs reference (num_cpus={num_cpus}): "
-          f"{'PASS' if ok else 'FAIL'}")
+    print(
+        f"[verify] sweep evals[1,1] vs reference (num_cpus={num_cpus}): "
+        f"{'PASS' if ok else 'FAIL'}"
+    )
     return ok
 
 
@@ -374,21 +415,41 @@ def main(argv: list[str] | None = None) -> int:
     global PROFILE
 
     parser = argparse.ArgumentParser(description="scqubits multiprocessing benchmark.")
-    parser.add_argument("--scenario", default="all",
-                        choices=["sweep", "hspace", "qubit", "all"])
-    parser.add_argument("--profile", default="light", choices=["light", "heavy"],
-                        help="workload size (heavy => MP can pay off)")
-    parser.add_argument("--num-cpus", default="1,2,4",
-                        help="comma-separated worker counts, e.g. '1,2,4'")
-    parser.add_argument("--grid", type=int, default=11,
-                        help="number of flux points (ng axis fixed at 3 for sweep)")
+    parser.add_argument(
+        "--scenario", default="all", choices=["sweep", "hspace", "qubit", "all"]
+    )
+    parser.add_argument(
+        "--profile",
+        default="light",
+        choices=["light", "heavy"],
+        help="workload size (heavy => MP can pay off)",
+    )
+    parser.add_argument(
+        "--num-cpus",
+        default="1,2,4",
+        help="comma-separated worker counts, e.g. '1,2,4'",
+    )
+    parser.add_argument(
+        "--grid",
+        type=int,
+        default=11,
+        help="number of flux points (ng axis fixed at 3 for sweep)",
+    )
     parser.add_argument("--repeats", type=int, default=5)
     parser.add_argument("--evals-count", type=int, default=20)
-    parser.add_argument("--verify", action="store_true",
-                        help="run the light 11x3 correctness guard against reference evals")
-    parser.add_argument("--json", nargs="?", const="<auto>", default=None,
-                        help="write results JSON (optional path; default under "
-                             "tools/benchmark_results/)")
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="run the light 11x3 correctness guard against reference evals",
+    )
+    parser.add_argument(
+        "--json",
+        nargs="?",
+        const="<auto>",
+        default=None,
+        help="write results JSON (optional path; default under "
+        "tools/benchmark_results/)",
+    )
     args = parser.parse_args(argv)
 
     PROFILE = args.profile
@@ -396,6 +457,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         import dill  # noqa: F401
         import pathos  # noqa: F401
+
         backend_available = True
     except ImportError:
         backend_available = False
@@ -406,12 +468,18 @@ def main(argv: list[str] | None = None) -> int:
             setattr(settings, flag, True)
 
     num_cpus_list = _parse_num_cpus(args.num_cpus, backend_available)
-    scenarios = ["sweep", "hspace", "qubit"] if args.scenario == "all" else [args.scenario]
+    scenarios = (
+        ["sweep", "hspace", "qubit"] if args.scenario == "all" else [args.scenario]
+    )
 
-    print(f"platform={platform.platform()}  cpu_count={os.cpu_count()}  "
-          f"MULTIPROC={settings.MULTIPROC}  scqubits={scq.__version__}")
-    print(f"profile={PROFILE}  num_cpus={num_cpus_list}  grid={args.grid}  "
-          f"repeats={args.repeats}  evals_count={args.evals_count}")
+    print(
+        f"platform={platform.platform()}  cpu_count={os.cpu_count()}  "
+        f"MULTIPROC={settings.MULTIPROC}  scqubits={scq.__version__}"
+    )
+    print(
+        f"profile={PROFILE}  num_cpus={num_cpus_list}  grid={args.grid}  "
+        f"repeats={args.repeats}  evals_count={args.evals_count}"
+    )
 
     if args.verify:
         _verify(num_cpus=1)
@@ -432,7 +500,9 @@ def main(argv: list[str] | None = None) -> int:
                     "scenario": scenario,
                     "profile": PROFILE,
                     "num_cpus": num_cpus,
-                    "grid_points": args.grid * 3 if scenario == "sweep" else max(args.grid, 50),
+                    "grid_points": (
+                        args.grid * 3 if scenario == "sweep" else max(args.grid, 50)
+                    ),
                     "evals_count": args.evals_count,
                     "repeats": args.repeats,
                     "speedup_vs_1": speedup,
@@ -446,8 +516,10 @@ def main(argv: list[str] | None = None) -> int:
     serialization = _measure_serialization(args)
     print("\n=== serialization payload (dill) ===")
     if serialization.get("available"):
-        print(f"HilbertSpace: {serialization['hilbertspace_bytes']:,} bytes  "
-              f"(dumps {serialization['hilbertspace_dumps_s'] * 1e3:.1f} ms)")
+        print(
+            f"HilbertSpace: {serialization['hilbertspace_bytes']:,} bytes  "
+            f"(dumps {serialization['hilbertspace_dumps_s'] * 1e3:.1f} ms)"
+        )
         print(f"update closure: {serialization['update_func_bytes']:,} bytes")
     else:
         print("dill unavailable; skipped.")


### PR DESCRIPTION
Reworks the multiprocessing path used by `ParameterSweep` (and the parallel spectrum methods) so that `num_cpus > 1` sweeps are fast and safe out of the box, and show live progress. Default (serial, `num_cpus = 1`) behavior is unchanged.

**What changes**

- **No BLAS oversubscription by default.** With `num_cpus` workers each running a BLAS that spawns one thread per core, the workers fight over the machine (`num_cpus × cores` threads) — the cause of the large slowdowns on dense parallel sweeps. The new setting `MULTIPROC_BLAS_THREADS` controls the per-worker cap and now defaults to **`"auto"`**: each worker is capped to `max(1, cores // num_cpus)`, so the workers together use about one thread per core and never oversubscribe. Set a positive int for a fixed cap (e.g. `1` for many small diagonalizations), or `None` to opt out and leave the thread environment untouched. The cap reaches spawn-based workers (macOS/Windows) through the thread-count environment variables and fork-based workers (Linux) through `threadpoolctl`; it is applied only while the pool is built, and the parent environment is restored afterward.

- **Worker-pool reuse.** A sweep issues several parallel `map` calls — one per bare subsystem, then the dressed system. The pool is now cached in `settings.POOL` and reused across those calls (matched on backend, start method, worker count, and BLAS cap), instead of a fresh pool per call, and is shut down at interpreter exit.

- **Correct start method per platform.** Parallel sweeps pin the process start method as a platform fact — `fork` on Linux, `spawn` on macOS and Windows — rather than leaving it to the backend default. macOS uses `spawn` because fork-after-threads is unsafe there. Under `spawn`, plain scripts need an `if __name__ == "__main__":` guard, so a one-time reminder is emitted when running outside one.

- **Less data shipped per grid point.** Each worker receives only that grid point's bare eigensystem through its work item, instead of `self` dragging the entire grid's bare-spectrum arrays into every worker (which `dill`'s `recurse=True` pulled in previously).

- **Live progress bars during multiprocessing.** Per-subsystem bars plus a dressed-system bar that advance per grid point (via `imap` with a `map`-equivalent chunksize, so throughput is unaffected). Finished "bare" bars stay visible above the "dressed" bar and clear together. Global state and bars are restored even if a sweep raises.

**Public surface**

- New setting `settings.MULTIPROC_BLAS_THREADS` — `"auto"` (default), a positive int, or `None`.
- `threadpoolctl` is now a runtime dependency (previously dev-only), so the default cap takes effect on Linux without extra setup.
- No public API removed. `NUM_CPUS = 1` (serial default) and `MULTIPROC = "pathos"` unchanged.

**Behavior change to note**

For `num_cpus > 1`, BLAS threads are now capped per worker by default. Numerical results are identical; the difference is that scqubits limits each worker's thread count (and briefly sets the thread-count environment variables) while building the pool. Users who manage BLAS threads themselves can restore the previous "untouched" behavior with `settings.MULTIPROC_BLAS_THREADS = None`.

**Anecdotal impact (one machine; highly machine- and workload-dependent)**

As a single illustrative data point — absolute numbers vary a lot across machines, BLAS builds, and workloads — a dense sweep of three capacitively coupled tunable transmons (dressed dimension 1728, 8 grid points, 20 eigenvalues) on a 10-core machine, with `num_cpus = 4`:

| | wall time |
|---|---:|
| `main` | ~683 s |
| this branch | ~5 s |

On `main` the four workers oversubscribed the cores (~40 BLAS threads on 10 cores; load average ~200), making `num_cpus = 4` roughly **95× slower than the same sweep run serially** (~7 s). This branch caps each worker to `10 // 4 = 2` BLAS threads, removing the oversubscription. The pure parallel gain over an already-tuned serial run is far more modest (~1.5–2× here) and grows with larger grids and systems; the dramatic figure above is about removing a default footgun, not about parallel scaling.

**Testing**

- Full suite + `--num_cpus=4` green on Linux/macOS/Windows × Python 3.10–3.12 (Azure).
- New tests in `test_cpu_switch.py`: cap resolution including `"auto"` (`cores // num_cpus`, floor of 1, override precedence), env-var capping mechanics, pool reuse and signature matching, pool→`None` pickle reduction, start-method resolution, spawn-guard warning. `test_parametersweep.py` exercises circuit and closure-based sweeps under multiprocessing.

*Not shipped in the package:* `tools/benchmark_multiprocessing.py` and `tools/BENCHMARKS.md` are maintainer benchmarking aids.
