### PR TITLE
Fix conda-build CI workflow (mambabuild removed upstream)

### DIFF
--- a/.github/workflows/mamba-install-and-run-pytests.yml
+++ b/.github/workflows/mamba-install-and-run-pytests.yml
@@ -1,4 +1,4 @@
-name: Locally install scqubits with mambabuild and run pytests
+name: Locally build scqubits with conda-build and run pytests
 
 on:
   workflow_dispatch:
@@ -47,10 +47,10 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-      - name: Build with mambabuild
+      - name: Build conda package
         run: |
-          conda install boa
-          conda mambabuild . --no-test
+          conda install -n base conda-build
+          conda build . --no-test
 
       - name: Install scqubits locally and run tests
         run: |


### PR DESCRIPTION
The manual (`workflow_dispatch`) conda-package smoke-test used `conda mambabuild`, which was removed from the conda-forge toolchain (boa deprecated), so the workflow failed on every dispatch. Switches to `conda install -n base conda-build` + `conda build . --no-test` (conda-build now ships the libmamba solver) and drops the stale "mambabuild" name. The recipe (`meta.yaml`, `noarch: python`) is unchanged.

**Testing**
- YAML validated. The conda build path itself is only verifiable by dispatching the workflow once after merge.
