### PR TITLE
Flag named-type Returns entries in docstring linter; clean up noise docstrings

### DIFF
--- a/scqubits/core/circuit_internals/noise.py
+++ b/scqubits/core/circuit_internals/noise.py
@@ -598,9 +598,8 @@ class NoisyCircuit(NoisySystem, ABC):
 
             Returns
             -------
-            time or rate: float
-                decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate
-                in inverse units.
+            decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate
+            in inverse units.
             """
             tphi_times = []
             for flux_sym in self.offset_charges:
@@ -904,8 +903,7 @@ class NoisyCircuit(NoisySystem, ABC):
 
             Returns
             -------
-            time or rate: float
-                decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate in inverse units.
+            decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate in inverse units.
             """
             return NoisySystem.t1_quasiparticle_tunneling(
                 self=self,
@@ -978,8 +976,7 @@ class NoisyCircuit(NoisySystem, ABC):
 
             Returns
             -------
-            time or rate: float
-                decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate in inverse units.
+            decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate in inverse units.
             """
             parent_circuit = self.return_parent_circuit()
             branch_var_expr = parent_circuit.symbolic_circuit._branch_sym_expr(
@@ -1091,9 +1088,8 @@ class NoisyCircuit(NoisySystem, ABC):
 
                 Returns
                 -------
-                time or rate: float
-                    decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate
-                    in inverse units.
+                decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate
+                in inverse units.
                 """
                 parent_circuit = self.return_parent_circuit()
                 branch_charge_expr = (
@@ -1160,9 +1156,8 @@ class NoisyCircuit(NoisySystem, ABC):
 
                 Returns
                 -------
-                time or rate: float
-                    decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate
-                    in inverse units.
+                decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate
+                in inverse units.
                 """
                 parent_circuit = self.return_parent_circuit()
                 branch_var_expr = parent_circuit.symbolic_circuit._branch_flux_expr(
@@ -1283,8 +1278,7 @@ class NoisyCircuit(NoisySystem, ABC):
 
             Returns
             -------
-            time or rate: float
-                decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate in inverse units.
+            decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate in inverse units.
             """
             t1_times = []
             for branch in [b for b in self.branches if "JJ" in b.type]:
@@ -1390,9 +1384,8 @@ class NoisyCircuit(NoisySystem, ABC):
 
             Returns
             -------
-            time or rate: float
-                decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate
-                in inverse units.
+            decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate
+            in inverse units.
             """
             t1_times = []
             parent_circuit = self.return_parent_circuit()
@@ -1491,9 +1484,8 @@ class NoisyCircuit(NoisySystem, ABC):
 
             Returns
             -------
-            time or rate: float
-                decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate
-                in inverse units.
+            decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate
+            in inverse units.
             """
             t1_times = []
             parent_circuit = self.return_parent_circuit()
@@ -1589,8 +1581,7 @@ class NoisyCircuit(NoisySystem, ABC):
 
             Returns
             -------
-            time or rate: float
-                decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate in inverse units.
+            decoherence time in units of :math:`2\pi ({\rm system\,\,units})`, or rate in inverse units.
             """
             t1_times = []
             parent_circuit = self.return_parent_circuit()
@@ -1688,9 +1679,8 @@ class NoisyCircuit(NoisySystem, ABC):
 
             Returns
             -------
-            time or rate: float
-                decoherence time in units of :math:`2\pi ({\rm system\,\,units})`,
-                or rate in inverse units.
+            decoherence time in units of :math:`2\pi ({\rm system\,\,units})`,
+            or rate in inverse units.
             """
             t1_times = []
             for external_flux_sym in self.external_fluxes:

--- a/scqubits/core/noise.py
+++ b/scqubits/core/noise.py
@@ -878,9 +878,8 @@ class NoisySystem(ABC):
 
         Returns
         -------
-        time or rate: float
-            decoherence time in units of :math:`2\pi` (system units), or
-            rate in inverse units.
+        decoherence time in units of :math:`2\pi` (system units), or
+        rate in inverse units.
         """
         common_noise_options = (
             {} if common_noise_options is None else common_noise_options
@@ -997,9 +996,8 @@ class NoisySystem(ABC):
 
         Returns
         -------
-        time or rate: float
-            decoherence time in units of :math:`2\pi` (system units),
-            or rate in inverse units.
+        decoherence time in units of :math:`2\pi` (system units),
+        or rate in inverse units.
         """
         # Sanity check
         if i == j or i < 0 or j < 0:
@@ -1073,9 +1071,8 @@ class NoisySystem(ABC):
 
         Returns
         -------
-        time or rate: float
-            decoherence time in units of :math:`2\pi` (system units), or
-            rate in inverse units.
+        decoherence time in units of :math:`2\pi` (system units), or
+        rate in inverse units.
         """
 
         if "tphi_1_over_f_flux" not in self.supported_noise_channels():
@@ -1120,9 +1117,8 @@ class NoisySystem(ABC):
 
         Returns
         -------
-        time or rate: float
-            decoherence time in units of :math:`2\pi` (system units), or
-            rate in inverse units.
+        decoherence time in units of :math:`2\pi` (system units), or
+        rate in inverse units.
         """
 
         if "tphi_1_over_f_cc" not in self.supported_noise_channels():
@@ -1167,9 +1163,8 @@ class NoisySystem(ABC):
 
         Returns
         -------
-        time or rate: float
-            decoherence time in units of :math:`2\pi` (system units), or rate
-            in inverse units.
+        decoherence time in units of :math:`2\pi` (system units), or rate
+        in inverse units.
         """
         if "tphi_1_over_f_ng" not in self.supported_noise_channels():
             raise RuntimeError(
@@ -1237,9 +1232,8 @@ class NoisySystem(ABC):
 
         Returns
         -------
-        time or rate: float
-            decoherence time in units of :math:`2\pi` (system units), or rate
-            in inverse units.
+        decoherence time in units of :math:`2\pi` (system units), or rate
+        in inverse units.
         """
 
         if settings.T1_DEFAULT_WARNING:
@@ -1332,9 +1326,8 @@ class NoisySystem(ABC):
 
         Returns
         -------
-        time or rate: float
-            decoherence time in units of :math:`2\pi` (system units), or rate
-             in inverse units.
+        decoherence time in units of :math:`2\pi` (system units), or rate
+         in inverse units.
         """
         if "t1_capacitive" not in self.supported_noise_channels():
             raise RuntimeError(
@@ -1433,8 +1426,7 @@ class NoisySystem(ABC):
 
         Returns
         -------
-        time or rate: float
-            decoherence time in units of :math:`2\pi` (system units), or rate in inverse units.
+        decoherence time in units of :math:`2\pi` (system units), or rate in inverse units.
         """
         if "t1_charge_impedance" not in self.supported_noise_channels():
             raise RuntimeError(
@@ -1523,9 +1515,8 @@ class NoisySystem(ABC):
 
         Returns
         -------
-        time or rate: float
-            decoherence time in units of :math:`2\pi` (system units),
-            or rate in inverse units.
+        decoherence time in units of :math:`2\pi` (system units),
+        or rate in inverse units.
         """
         if "t1_flux_bias_line" not in self.supported_noise_channels():
             raise RuntimeError(
@@ -1610,9 +1601,8 @@ class NoisySystem(ABC):
 
         Returns
         -------
-        time or rate: float
-            decoherence time in units of :math:`2\pi` (system units), or rate
-            in inverse units.
+        decoherence time in units of :math:`2\pi` (system units), or rate
+        in inverse units.
         """
         if "t1_inductive" not in self.supported_noise_channels():
             raise RuntimeError(
@@ -1729,8 +1719,7 @@ class NoisySystem(ABC):
 
         Returns
         -------
-        time or rate: float
-            decoherence time in units of :math:`2\pi` (system units), or rate in inverse units.
+        decoherence time in units of :math:`2\pi` (system units), or rate in inverse units.
         """
         if "t1_quasiparticle_tunneling" not in self.supported_noise_channels():
             raise RuntimeError(

--- a/scqubits/core/noise.py
+++ b/scqubits/core/noise.py
@@ -777,7 +777,7 @@ class NoisySystem(ABC):
         Returns
         -------
         decoherence time in units of :math:`2\pi` (system units), or rate
-         in inverse units.
+        in inverse units.
         """
         common_noise_options = (
             {} if common_noise_options is None else common_noise_options
@@ -1327,7 +1327,7 @@ class NoisySystem(ABC):
         Returns
         -------
         decoherence time in units of :math:`2\pi` (system units), or rate
-         in inverse units.
+        in inverse units.
         """
         if "t1_capacitive" not in self.supported_noise_channels():
             raise RuntimeError(

--- a/tools/docstring_lint.py
+++ b/tools/docstring_lint.py
@@ -302,9 +302,10 @@ _PARAM_TYPE_LINE = re.compile(
 # Heuristic for a numpydoc *Returns* entry that names both a value and its type,
 # e.g. ``time or rate : float`` / ``result: ndarray``.  Unlike a parameter name,
 # the value name may be a free-text phrase, so the name group is permissive; the
-# RHS is type-checked by ``_looks_like_a_type`` before flagging.  Non-greedy name
-# stops at the first ``:`` so a description with an embedded ``:math:`` role does
-# not match.
+# RHS is type-checked by ``_looks_like_a_type`` before flagging.  The non-greedy
+# name stops at the first ``:``, so a description with an embedded ``:math:`` role
+# still matches (split before the role) but is not flagged, because its RHS is not
+# a bare type.
 _RETURNS_NAMED_TYPE_LINE = re.compile(r"^(?P<name>.+?)\s*:\s*(?P<rhs>\S.*)$")
 
 

--- a/tools/docstring_lint.py
+++ b/tools/docstring_lint.py
@@ -299,6 +299,15 @@ _PARAM_TYPE_LINE = re.compile(
 )
 
 
+# Heuristic for a numpydoc *Returns* entry that names both a value and its type,
+# e.g. ``time or rate : float`` / ``result: ndarray``.  Unlike a parameter name,
+# the value name may be a free-text phrase, so the name group is permissive; the
+# RHS is type-checked by ``_looks_like_a_type`` before flagging.  Non-greedy name
+# stops at the first ``:`` so a description with an embedded ``:math:`` role does
+# not match.
+_RETURNS_NAMED_TYPE_LINE = re.compile(r"^(?P<name>.+?)\s*:\s*(?P<rhs>\S.*)$")
+
+
 # Set of Python type names (built-ins + scqubits-relevant) that should be
 # recognized as types when they appear bare in a docstring.  Used by both
 # ``_looks_like_a_type`` (Parameters RHS) and ``_looks_like_bare_type_line``
@@ -462,9 +471,11 @@ def _has_return_annotation(node: ast.AST) -> bool:
 class TypesInDocstringCheck(Check):
     """DOC002 -- flags type annotations duplicated into the docstring.
 
-    Catches both the numpydoc ``name : type`` Parameters form *and* the
-    bare-type-on-first-line Returns form.  The rule fires only when
-    the function signature *already* carries the annotation -- i.e.
+    Catches the numpydoc ``name : type`` Parameters form and, in a
+    Returns/Yields section, both the bare-type-on-first-line form
+    (``float``) and the named ``name : type`` form (``time or rate :
+    float``).  The rule fires only when the function signature
+    *already* carries the annotation -- i.e.
     when the docstring is duplicating information that the type
     system already has.  Functions without signature annotations
     legitimately use the docstring as the type source and are not
@@ -536,30 +547,45 @@ class TypesInDocstringCheck(Check):
             )
 
     def _check_returns(self, section, start_line, body):
-        # Only invoked when the function has a ``-> ...`` annotation,
-        # so a bare-type first line in the section is genuinely
-        # duplicating the signature.  First non-blank body line: if it
-        # parses as a bare type (one identifier, possibly with
-        # ``[...]`` / ``|``), flag it.
+        # Only invoked when the function has a ``-> ...`` annotation, so a type
+        # in the section is genuinely duplicating the signature.  Inspect the
+        # first non-blank body line and flag either form numpydoc allows for a
+        # typed return:
+        #   - a bare type on its own line (``float``), or
+        #   - a named entry whose RHS is purely a type (``time or rate : float``).
+        # Anything else is a description and is left alone.
         body_lines = body.splitlines()
         for offset, line in enumerate(body_lines, start=1):
             if not line.strip():
                 continue
             stripped = line.strip()
-            if not _looks_like_bare_type_line(stripped):
-                return  # description first -- fine
             line_in_doc = start_line + 1 + offset
-            yield (
-                line_in_doc,
-                f"`{section}` section starts with bare type `{stripped}` "
-                f"(signature already declares the return type)",
-                stripped,
-                f"Drop the bare-type first line and put the description "
-                f"directly under the `{section}` header.  The signature's "
-                f"`-> {stripped}` annotation is the source of truth; "
-                f"Sphinx with napoleon surfaces the type from there.",
-            )
-            return
+            if _looks_like_bare_type_line(stripped):
+                yield (
+                    line_in_doc,
+                    f"`{section}` section starts with bare type `{stripped}` "
+                    f"(signature already declares the return type)",
+                    stripped,
+                    f"Drop the bare-type first line and put the description "
+                    f"directly under the `{section}` header.  The signature's "
+                    f"`-> {stripped}` annotation is the source of truth; "
+                    f"Sphinx with napoleon surfaces the type from there.",
+                )
+                return
+            named = _RETURNS_NAMED_TYPE_LINE.match(stripped)
+            if named and _looks_like_a_type(named.group("rhs")):
+                rhs = named.group("rhs").strip()
+                name = named.group("name").strip()
+                yield (
+                    line_in_doc,
+                    f"`{section}` entry `{name}` carries type `{rhs}` "
+                    f"(signature already declares the return type)",
+                    stripped,
+                    f"Drop the `: {rhs}` from the `{section}` entry and keep only "
+                    f"the description.  The signature's `-> {rhs}` annotation is "
+                    f"the source of truth; Sphinx with napoleon surfaces the type.",
+                )
+            return  # first non-blank line decides it
 
 
 # Phrases that indicate the docstring is narrating change history rather

--- a/tools/test_docstring_lint.py
+++ b/tools/test_docstring_lint.py
@@ -297,6 +297,42 @@ def test_types_in_docstring_check_silent_on_returns_with_description() -> None:
     assert issues == []
 
 
+def test_types_in_docstring_check_flags_returns_with_named_type() -> None:
+    """DOC002 flags a numpydoc ``name : type`` Returns entry whose RHS is a
+    type (e.g. ``time or rate : float``), not only the bare-type form."""
+    source = textwrap.dedent("""\
+        def foo() -> float:
+            \"\"\"Summary.
+
+            Returns
+            -------
+            time or rate: float
+                the coherence time or rate.
+            \"\"\"
+        """)
+    issues = [i for i in lint_source(source, "fixture.py") if i.check_id == "DOC002"]
+    assert len(issues) == 1
+    assert "Returns" in issues[0].message
+    assert issues[0].snippet == "time or rate: float"
+
+
+def test_types_in_docstring_check_silent_on_returns_with_named_prose() -> None:
+    """A ``name: prose`` Returns entry (RHS is a description, not a type) is
+    fine -- DOC002 must not flag it."""
+    source = textwrap.dedent("""\
+        def foo() -> float:
+            \"\"\"Summary.
+
+            Returns
+            -------
+            result: the frequency in Hz
+                more detail.
+            \"\"\"
+        """)
+    issues = [i for i in lint_source(source, "fixture.py") if i.check_id == "DOC002"]
+    assert issues == []
+
+
 def test_work_narrative_check_flags_we_used_to() -> None:
     docstring = "We used to compute this differently."
     issues = _run_check_on_docstring(WorkNarrativeCheck(), docstring)


### PR DESCRIPTION
Closes a gap in the docstring linter and cleans up the duplications it then exposed.

**Tool fix (`tools/docstring_lint.py`)**

DOC002 ("types belong in the signature, not the docstring") only caught a **bare type on the first line** of a `Returns` section (`float`). It missed the numpydoc **named form** `name : type` — e.g. `time or rate : float` — so a type duplicated into a named Returns entry passed silently. `_check_returns` now also flags the named form, but only when the RHS is *purely* a type and the function carries a `-> ...` annotation; prose entries (`result: the frequency in Hz`), `:math:` roles, and plain descriptions are untouched. Adds `_RETURNS_NAMED_TYPE_LINE` and two tests.

**Docstring cleanup (`scqubits/core/noise.py`, `scqubits/core/circuit_internals/noise.py`)**

A full scan with the corrected linter surfaced 21 pre-existing `time or rate : float` Returns entries (grandfathered because the linter's baseline mode only reports regressions). Removed the redundant `: float` from the annotated coherence methods — 11 in `noise.py`, 10 in `circuit_internals/noise.py` — keeping the description only. One un-annotated nested function is left as-is: its docstring type is the legitimate source there, and the linter correctly does not flag it.

**Testing**
- `tools/test_docstring_lint.py`: 67 pass (2 new).
- Full docstring-lint scan of `scqubits/` + `tools/`: clean.
- `test_noise.py` green; mypy unchanged (docstring-only); black clean.
