### PR TITLE
Close GUI icon files after reading (fix ResourceWarning)

### DIFF
--- a/scqubits/ui/gui_defaults.py
+++ b/scqubits/ui/gui_defaults.py
@@ -44,8 +44,8 @@ if _HAS_IPYVUETIFY:
 
     for name in gui_icon_filenames:
         full_path = os.path.join(path, name)
-        file = open(full_path, "rb")
-        image = file.read()
+        with open(full_path, "rb") as file:
+            image = file.read()
         image_base64 = base64.b64encode(image).decode("ascii")
         icons[name] = v.Img(src=f"data:image/png;base64,{image_base64}", width=50)
 


### PR DESCRIPTION
`scqubits/ui/gui_defaults.py` loaded each GUI icon PNG with a bare `open(...)` whose handle was never closed. The loop variable `file` was reassigned each iteration, so most handles were garbage-collected mid-loop, but the **last** icon — `scq-logo.png` — stayed referenced by the leftover module-level `file` global until interpreter shutdown, where its finalizer emitted:

```
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name='.../scqubits/ui/icons/scq-logo.png'>
```

Harmless (the file is fully read, and closed at exit anyway) but untidy, and it shows up at the end of any session that imports the GUI defaults. Fix: read the bytes inside a `with open(...) as file:` so each handle closes immediately.

**Testing**
- The leftover `file` global is now `closed == True` after import (was open); `icons` still contains every entry including `scq-logo.png`. Running under `-W error::ResourceWarning` no longer trips at shutdown.
