### PR TITLE
fix: Oscillator.create() fails on Linux due to image filename case mismatch

### DIFF
--- a/scqubits/core/oscillator.py
+++ b/scqubits/core/oscillator.py
@@ -133,7 +133,9 @@ class Oscillator(base.QuantumSystem, serializers.Serializable):
         self.l_osc: float | None = l_osc  # type: ignore[no-redef, assignment]
         self.E_osc = E_osc
         self._image_filename = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "qubit_img/oscillator.jpg"
+            os.path.dirname(os.path.abspath(__file__)),
+            "qubit_img",
+            type(self).__name__ + ".jpg",
         )
 
     @staticmethod
@@ -269,7 +271,9 @@ class KerrOscillator(Oscillator, serializers.Serializable):
         )
 
         self._image_filename = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "qubit_img/KerrOscillator.jpg"
+            os.path.dirname(os.path.abspath(__file__)),
+            "qubit_img",
+            type(self).__name__ + ".jpg",
         )
 
     @staticmethod


### PR DESCRIPTION
## Problem

`Oscillator.create()` raises `FileNotFoundError` on Linux. `Oscillator.__init__` hardcoded its widget image as `qubit_img/oscillator.jpg`, but the bundled file is `qubit_img/Oscillator.jpg`. On case-sensitive filesystems (Linux) the `open()` in the creation widget fails; macOS/Windows resolve it case-insensitively, which is why it slipped through.

Reported against the released version; the bug is present on `main` and in `v4.3.1`.

## Fix

Build the image path from `type(self).__name__ + ".jpg"` in both `Oscillator` and `KerrOscillator`, mirroring how `QubitBaseClass.__init__` derives the image for every other qubit. The filename now always tracks the class name, so the capitalization can't drift again — and it removes the only two hand-typed image-filename literals in the core qubit classes.

```python
# before (Oscillator)
self._image_filename = os.path.join(
    os.path.dirname(os.path.abspath(__file__)), "qubit_img/oscillator.jpg"
)
# after (both Oscillator and KerrOscillator)
self._image_filename = os.path.join(
    os.path.dirname(os.path.abspath(__file__)),
    "qubit_img",
    type(self).__name__ + ".jpg",
)
```

## Scope check

I scanned every bundled-file reference for the same class-mismatch class of bug:

- **`qubit_img/*.jpg`** — the only hardcoded references were these two in `oscillator.py`. `KerrOscillator.jpg` happened to be spelled correctly; `oscillator.jpg` was not. Every other qubit already uses the dynamic class-name path, and each `ClassName.jpg` exists with exact case.
- **`ui/icons/*.png`** (`En.png`, `psi.png`, `Me.png`, `MeS.png`, `T1.png`, `scq-logo.png`) — all referenced with exact on-disk case. No issue.
- **`GenericQubit`** has no `GenericQubit.jpg`, but its `create()`/`widget()` raise `NotImplementedError`, so no image is ever loaded — intentional, not a bug.

Verified the fixed path resolves to an exactly-cased, existing file for both classes (case-sensitive `os.listdir` membership, since `os.path.exists` is case-insensitive on macOS).