### PR TITLE
fix: plot Cos2PhiQubit wavefunctions in the GUI (AttributeError on _default_grid)

### DIFF
--- a/scqubits/ui/gui.py
+++ b/scqubits/ui/gui.py
@@ -885,17 +885,29 @@ class GUI:
                 "multi_state_selector"
             ].v_model
 
+        # Most qubits expose a single ``_default_grid``; Cos2PhiQubit instead has
+        # separate ``_default_phi_grid``/``_default_theta_grid``. Fall back to the
+        # per-axis grid when ``_default_grid`` is absent so its wavefunction plots
+        # do not raise AttributeError in the GUI.
         if isinstance(self.active_qubit, QUBITS_WITH_PHI_GRID):
+            phi_default = (
+                getattr(self.active_qubit, "_default_grid", None)
+                or self.active_qubit._default_phi_grid
+            )
             value_dict["phi_grid"] = Grid1d(
                 min_val=cast(float, self.dict_v_ranges["phi"]["min"].num_value),
                 max_val=cast(float, self.dict_v_ranges["phi"]["max"].num_value),
-                pt_count=self.active_qubit._default_grid.pt_count,
+                pt_count=phi_default.pt_count,
             )
         if isinstance(self.active_qubit, QUBITS_WITH_THETA_GRID):
+            theta_default = (
+                getattr(self.active_qubit, "_default_grid", None)
+                or self.active_qubit._default_theta_grid
+            )
             value_dict["theta_grid"] = Grid1d(
                 min_val=cast(float, self.dict_v_ranges["theta"]["min"].num_value),
                 max_val=cast(float, self.dict_v_ranges["theta"]["max"].num_value),
-                pt_count=self.active_qubit._default_grid.pt_count,
+                pt_count=theta_default.pt_count,
             )
         self.wavefunctions_plot(**value_dict)
 

--- a/scqubits/ui/gui.py
+++ b/scqubits/ui/gui.py
@@ -890,9 +890,8 @@ class GUI:
         # per-axis grid when ``_default_grid`` is absent so its wavefunction plots
         # do not raise AttributeError in the GUI.
         if isinstance(self.active_qubit, QUBITS_WITH_PHI_GRID):
-            phi_default = (
-                getattr(self.active_qubit, "_default_grid", None)
-                or self.active_qubit._default_phi_grid
+            phi_default = getattr(self.active_qubit, "_default_grid", None) or getattr(
+                self.active_qubit, "_default_phi_grid"
             )
             value_dict["phi_grid"] = Grid1d(
                 min_val=cast(float, self.dict_v_ranges["phi"]["min"].num_value),
@@ -900,10 +899,9 @@ class GUI:
                 pt_count=phi_default.pt_count,
             )
         if isinstance(self.active_qubit, QUBITS_WITH_THETA_GRID):
-            theta_default = (
-                getattr(self.active_qubit, "_default_grid", None)
-                or self.active_qubit._default_theta_grid
-            )
+            theta_default = getattr(
+                self.active_qubit, "_default_grid", None
+            ) or getattr(self.active_qubit, "_default_theta_grid")
             value_dict["theta_grid"] = Grid1d(
                 min_val=cast(float, self.dict_v_ranges["theta"]["min"].num_value),
                 max_val=cast(float, self.dict_v_ranges["theta"]["max"].num_value),


### PR DESCRIPTION
## Problem

Plotting `Cos2PhiQubit` wavefunctions in the GUI raised `AttributeError`. `GUI.wavefunctions_plot_refresh` reads `self.active_qubit._default_grid.pt_count` for every member of `QUBITS_WITH_PHI_GRID` / `QUBITS_WITH_THETA_GRID`, but `Cos2PhiQubit` has no `_default_grid` — it exposes separate `_default_phi_grid` and `_default_theta_grid`.

Verified against `main`: `Transmon`, `TunableTransmon`, `Fluxonium`, `FluxQubit`, `ZeroPi` define `_default_grid`; `Cos2PhiQubit` defines only `_default_phi_grid` / `_default_theta_grid`.

## Fix

Fall back to the per-axis grid when `_default_grid` is absent, using a short-circuit `or` so the fallback attribute is only accessed for qubits that actually have it:

```python
phi_default = (
    getattr(self.active_qubit, "_default_grid", None)
    or self.active_qubit._default_phi_grid
)
...
pt_count=phi_default.pt_count,
```
(and the analogous `_default_theta_grid` for the theta branch).

The lazy `or` matters: an eager fallback like `getattr(obj, "_default_grid", getattr(obj, "_default_phi_grid"))` would itself raise `AttributeError` for `Transmon`/`Fluxonium`/etc. (which lack `_default_phi_grid`). `Grid1d` has no `__bool__`/`__len__`, so it is always truthy and the short-circuit is safe.

## Verification

Replicated the exact `pt_count` resolution against real instances of every set member — all resolve with no `AttributeError`:

| qubit | branch | source | pt_count |
|---|---|---|---|
| Transmon / TunableTransmon / Fluxonium | phi | `_default_grid` | 151 |
| FluxQubit | phi | `_default_grid` | 100 |
| Cos2PhiQubit | phi | `_default_phi_grid` (fallback) | 100 |
| ZeroPi | theta | `_default_grid` | 200 |
| Cos2PhiQubit | theta | `_default_theta_grid` (fallback) | 100 |

## Credit

Supersedes #275 by @PositroniumJS, which identified this bug and the `Cos2PhiQubit` grid mismatch. This reimplements the fix cleanly on current `main` (the original also carried now-redundant `zeropi.py` docstring edits and used an eager `getattr` fallback that would have regressed the single-grid qubits).