### PR TITLE
fix: WatchedProperty broadcasts dispatch events only on actual value change (#276)

### DIFF
--- a/scqubits/core/descriptors.py
+++ b/scqubits/core/descriptors.py
@@ -41,11 +41,8 @@ def _values_equal(new_value: Any, old_value: Any) -> bool:
         return True
     try:
         result = new_value == old_value
-    except (TypeError, ValueError):
-        return False
-    if isinstance(result, np.ndarray) or hasattr(result, "__iter__"):
-        return bool(np.all(result))
-    try:
+        if isinstance(result, np.ndarray) or hasattr(result, "__iter__"):
+            return bool(np.all(result))
         return bool(result)
     except (TypeError, ValueError):
         return False

--- a/scqubits/core/descriptors.py
+++ b/scqubits/core/descriptors.py
@@ -16,9 +16,39 @@ from __future__ import annotations
 
 from typing import Any, Generic, Type, TypeVar
 
+import numpy as np
+
 from scqubits.core.central_dispatch import DispatchClient
 
 TargetType = TypeVar("TargetType")
+
+
+def _values_equal(new_value: Any, old_value: Any) -> bool:
+    """Return whether two watched-property values are equal.
+
+    Handles array-like values (where ``==`` yields an element-wise array) by
+    reducing with :func:`numpy.all`, and treats any comparison that cannot be
+    evaluated as "not equal" so the assignment is allowed to proceed.
+
+    Parameters
+    ----------
+    new_value:
+        value being assigned.
+    old_value:
+        value currently stored.
+    """
+    if new_value is old_value:
+        return True
+    try:
+        result = new_value == old_value
+    except (TypeError, ValueError):
+        return False
+    if isinstance(result, np.ndarray) or hasattr(result, "__iter__"):
+        return bool(np.all(result))
+    try:
+        return bool(result)
+    except (TypeError, ValueError):
+        return False
 
 
 class ReadOnlyProperty(Generic[TargetType]):
@@ -153,11 +183,13 @@ class WatchedProperty(Generic[TargetType]):
             return self.getter(instance)
 
     def __set__(self, instance: DispatchClient, value: TargetType) -> None:
-        """Set the watched value and trigger ``broadcast`` of ``self.event``.
+        """Store the watched value and broadcast ``self.event`` when it changes.
 
         Dispatches through ``fset``/``inner`` if configured. The broadcast is
         suppressed on the first assignment (when neither ``attr_name`` nor
-        ``_attr_name`` is yet present on the instance).
+        ``_attr_name`` is yet present on the instance) and on any later
+        reassignment whose value equals the one already stored; the value is
+        still written on the first assignment regardless.
 
         Parameters
         ----------
@@ -172,18 +204,21 @@ class WatchedProperty(Generic[TargetType]):
             # Rely on inner_instance.attr_name to do the broadcasting.
         else:
             assert self.attr_name
-            if (
+            first_assignment = (
                 self.attr_name not in instance.__dict__
                 and f"_{self.attr_name}" not in instance.__dict__
+            )
+            # Always initialize on the first assignment; afterwards, write and
+            # broadcast only when the value actually changes. The old value is
+            # read through __get__ so it works for both plain and fget/fset
+            # (``_attr_name``-backed) properties. The ``or`` short-circuits, so
+            # __get__ is never called before the value exists.
+            if first_assignment or not _values_equal(
+                value, self.__get__(instance, type(instance))
             ):
                 if self.setter is None:
                     instance.__dict__[self.attr_name] = value
                 else:
                     self.setter(instance, value, name=self.attr_name)
-                # Rely on inner_instance.attr_name to do the broadcasting.
-            else:
-                if self.setter is None:
-                    instance.__dict__[self.attr_name] = value
-                else:
-                    self.setter(instance, value, name=self.attr_name)
-                instance.broadcast(self.event)
+                if not first_assignment:
+                    instance.broadcast(self.event)

--- a/scqubits/tests/test_centraldispatch.py
+++ b/scqubits/tests/test_centraldispatch.py
@@ -72,3 +72,59 @@ class TestCentralDispatch:
             in caplog.text
         )
         central_dispatch.LOGGER.setLevel(logging.WARNING)
+
+
+class _EventCounter(central_dispatch.DispatchClient):
+    """Test listener that counts dispatched events of a chosen type.
+
+    The instance must be kept referenced for the lifetime of the check, since
+    CentralDispatch holds its callback only weakly.
+    """
+
+    def __init__(self, event):
+        self._watched_event = event
+        self.count = 0
+        central_dispatch.CENTRAL_DISPATCH.register(event, self)
+
+    def receive(self, event, sender, **kwargs):
+        if event == self._watched_event:
+            self.count += 1
+
+
+class TestWatchedPropertyEquality:
+    """A WatchedProperty broadcasts only when its value actually changes (issue #276)."""
+
+    def test_values_equal_handles_scalars_arrays_and_none(self):
+        from scqubits.core.descriptors import _values_equal
+
+        assert _values_equal(5.0, 5.0)
+        assert not _values_equal(5.0, 6.0)
+        assert _values_equal(None, None)
+        assert not _values_equal(None, 5.0)
+        assert _values_equal(np.array([1.0, 2.0]), np.array([1.0, 2.0]))
+        assert not _values_equal(np.array([1.0, 2.0]), np.array([1.0, 3.0]))
+        # shape mismatch must not raise -- treated as not equal
+        assert not _values_equal(np.array([1.0, 2.0]), np.array([1.0, 2.0, 3.0]))
+
+    def test_no_broadcast_during_construction(self):
+        counter = _EventCounter("QUANTUMSYSTEM_UPDATE")
+        scq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=30)
+        assert counter.count == 0
+
+    def test_broadcast_on_value_change(self):
+        qbt = scq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=30)
+        counter = _EventCounter("QUANTUMSYSTEM_UPDATE")
+        qbt.EJ = 18.0
+        assert counter.count == 1
+
+    def test_no_broadcast_on_same_value(self):
+        qbt = scq.Transmon(EJ=15.0, EC=0.3, ng=0.0, ncut=30)
+        counter = _EventCounter("QUANTUMSYSTEM_UPDATE")
+        qbt.EJ = qbt.EJ  # reassigning the identical value must not broadcast
+        assert counter.count == 0
+
+    def test_none_default_first_assignment_is_initialized(self):
+        # Oscillator's l_osc defaults to None; the same-value short-circuit must not
+        # skip the first assignment, or reading l_osc later raises KeyError.
+        osc = scq.Oscillator(E_osc=5.0, truncated_dim=10)
+        assert osc.l_osc is None


### PR DESCRIPTION
Closes #276. Reimplements #277 by @adriendilonardo on current `main`, with the broadcast/initialization logic corrected and regression tests added.

## Problem (#276)

Reassigning a `WatchedProperty` its *current* value still re-ran the setter and broadcast a `QUANTUMSYSTEM_UPDATE`, causing redundant downstream updates.

## Why #277 couldn't merge

#277 had the right idea (an equality short-circuit) but conflated "should I **broadcast**?" with "should I **set**?", losing `main`'s pre-set first-assignment detection. That produced two failures (both verified):

- **All-platform CI failure — `KeyError('l_osc')`.** `Oscillator` is built with `l_osc=None` by default; the "skip when equal" check saw `None == __dict__.get("l_osc", None)` → `True` on the *first* assignment and skipped storing it, so the next read raised `KeyError`. Broke `test_hilbertspace` on every Linux/Windows/macOS job.
- **Spurious construction broadcasts (0 → 5).** Its broadcast gate was evaluated *after* the store, so the first assignment always broadcast — firing 5 `QUANTUMSYSTEM_UPDATE`s while building a Transmon, which `main` deliberately suppresses.

It also read `__dict__.get(self.attr_name)`, which misses `fget`/`fset` properties stored under `_name` (Copilot's review noted this), placed `import numpy` out of group, and shipped trailing whitespace (failing `black --check`).

## This PR

- Keeps the first-assignment detection (membership check **before** the store) and **always initializes** on first assignment — no `KeyError`.
- On reassignment, writes and broadcasts **only when the value changed**, reading the old value through `__get__` so it is storage-agnostic (plain and `fget`/`fset` properties alike).
- `_values_equal` compares scalars and array-valued properties (element-wise via `numpy.all`) and treats an unevaluable comparison as "changed".
- Fixes the import grouping; updates the `__set__` docstring.

## Behavior

| scenario | before | after |
|---|---|---|
| events during construction | 0 | **0** |
| real value change | 1 | **1** |
| same-value reassignment | 1 (the bug) | **0** |
| `Oscillator(l_osc=None)` then read | ok | **ok** (no `KeyError`) |

## Tests (added to `test_centraldispatch.py`)

`_values_equal` over scalars/arrays/None/shape-mismatch; no broadcast on construction; one on a real change; none on same-value reassignment; and that a `None`-default first assignment is initialized (guards the `KeyError` regression).

## Verification

`uv run pytest` → 541 passed / 14 skipped; `black --check` clean; `descriptors.py` mypy-clean (only the known numpy-2 baseline noise elsewhere); docstring lint clean.