### PR TITLE
fix(convergence): unit-aware energy path (GHz regardless of set_units) [#306]

### DIFF
--- a/scqubits/core/convergence.py
+++ b/scqubits/core/convergence.py
@@ -898,7 +898,7 @@ class ConvergenceCheckable:
                     evals_step1[:n_levels],
                     clusters,
                     settings.CONVERGENCE_MONOTONICITY_REL_TOL,
-                    _REFINEMENT_NOISE_FLOOR_GHz,
+                    _REFINEMENT_NOISE_FLOOR_GHz / _GHz_factor(),
                 )
 
             clone_step2: ConvergenceCheckable | None = None
@@ -920,7 +920,7 @@ class ConvergenceCheckable:
                         evals_step2[:n_levels],
                         clusters,
                         settings.CONVERGENCE_MONOTONICITY_REL_TOL,
-                        _REFINEMENT_NOISE_FLOOR_GHz,
+                        _REFINEMENT_NOISE_FLOOR_GHz / _GHz_factor(),
                     )
             if use_richardson and diff_step2 is not None:
                 # Per-axis absolute estimate (Richardson for an h**p FD-stencil
@@ -1710,6 +1710,11 @@ def _local_isolation_gap(
 
     The returned gap is floored at ``g_floor``.
     """
+    # ``g_floor`` is specified in GHz, but the gaps are eigenvalue differences in
+    # the active unit system; rescale it to the active units so the floor binds at
+    # the same physical gap (and the resulting eps = err/gap stays unit-invariant)
+    # regardless of set_units. Identity under GHz.
+    g_floor = g_floor / _GHz_factor()
     if k == 0:
         if n_levels < 2:
             return None
@@ -1826,7 +1831,8 @@ def _per_cluster_energy_estimates(
                 if cluster_max_diff_step2 is not None
                 else 0.0
             )
-            if d0 <= _REFINEMENT_NOISE_FLOOR_GHz and d1 <= _REFINEMENT_NOISE_FLOOR_GHz:
+            noise_floor = _REFINEMENT_NOISE_FLOOR_GHz / _GHz_factor()
+            if d0 <= noise_floor and d1 <= noise_floor:
                 # Both refinements are flat at the eigensolver noise floor: no
                 # real movement, so the undefined ratio is not a dismissal. The
                 # safety factor keeps the (negligible) reported estimate a

--- a/scqubits/core/convergence.py
+++ b/scqubits/core/convergence.py
@@ -50,6 +50,22 @@ from scqubits.core.convergence_report import (
 )
 
 
+def _GHz_factor() -> float:
+    """Multiplier converting an energy value from the active unit system to GHz.
+
+    The convergence diagnostics report energy quantities (the ``*_GHz`` error
+    estimates and channel weights) in GHz. Eigenvalues -- and every energy
+    derived from them -- come out of ``eigensys`` in the active unit system (see
+    :func:`scqubits.set_units`). Internal computation is kept in the active units
+    so it stays consistent with the qubit parameters and the physics hooks
+    (potential-envelope box refinement, the perturbative tail estimate, coherence
+    ``esys``); this factor converts the per-level error estimates to GHz only at
+    the reporting boundary. It is ``1.0`` when the active units are already GHz.
+    The coherence path normalizes rates to Hz for the same reason.
+    """
+    return units.units_scale_factor() / 1e9
+
+
 class ConvergenceCheckable:
     """Mixin providing :meth:`check_convergence` for qubit classes.
 
@@ -728,6 +744,10 @@ class ConvergenceCheckable:
             eps = est / gap if gap is not None else None
             if scope == "observed_gap_scale" and gap is None:
                 warnings.append("upper_gap_unavailable")
+            # ``eps`` (a dimensionless est/gap ratio) was formed in the active
+            # units; convert the absolute estimate to GHz for the target check
+            # and the reported abs_err_est_GHz field. Identity under GHz.
+            est = est * _GHz_factor()
 
             if float(boundary_prob[k]) > large_boundary_prob:
                 # The kept eigenstate reaches the basis edge: a dismissal signal.
@@ -1147,6 +1167,18 @@ class ConvergenceCheckable:
             per_level_abs_err=per_level_abs_err,
             per_level_warnings=per_level_warnings,
         )
+
+        # ``per_level_abs_err`` and ``eps_gap_est`` were computed in the active
+        # unit system (eigenvalue differences). ``eps_gap_est`` is a dimensionless
+        # ratio and stays correct; convert the absolute estimate to GHz now -- after
+        # the ratio, before the target check and the abs_err_est_GHz / transition /
+        # channel-breakdown report fields. Identity under GHz.
+        ghz_factor = _GHz_factor()
+        per_level_abs_err = per_level_abs_err * ghz_factor
+        channel_breakdown = {
+            channel: weight * ghz_factor
+            for channel, weight in channel_breakdown.items()
+        }
 
         per_level_status = _assign_level_statuses(
             n_levels=n_levels,

--- a/scqubits/tests/test_convergence.py
+++ b/scqubits/tests/test_convergence.py
@@ -18,6 +18,7 @@ and the top-level ``check_convergence`` shim.
 from __future__ import annotations
 
 import dataclasses
+import warnings
 
 import numpy as np
 import pytest
@@ -213,6 +214,35 @@ class TestEnergyModerateMode:
         assert report.aggregate_status == "distrust"
         # Recommendation should propose increasing ncut.
         assert any("ncut" in r for r in report.recommendations)
+
+    @pytest.mark.parametrize("mode", ["cheap", "moderate", "strict"])
+    def test_abs_err_estimate_is_unit_invariant(self, mode):
+        # The same physical transmon expressed in GHz vs MHz must yield the same
+        # abs_err_est_GHz and the same verdict: the energy diagnostics report in
+        # GHz regardless of the active unit system (regression for the
+        # GHz-hardcoding raised in issue #306). under-converged (ncut=5) so the
+        # error is a real truncation error, well above the eigensolver floor.
+        original_units = sq.get_units()
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                sq.set_units("GHz")
+                rep_ghz = sq.Transmon(
+                    EJ=15.0, EC=0.3, ng=0.0, ncut=5, truncated_dim=6
+                ).check_convergence(n_levels=4, mode=mode, target_abs_GHz=1e-3)
+                sq.set_units("MHz")
+                rep_mhz = sq.Transmon(
+                    EJ=15000.0, EC=300.0, ng=0.0, ncut=5, truncated_dim=6
+                ).check_convergence(n_levels=4, mode=mode, target_abs_GHz=1e-3)
+        finally:
+            sq.set_units(original_units)
+        err_ghz = [v.abs_err_est_GHz for v in rep_ghz.per_level]
+        err_mhz = [v.abs_err_est_GHz for v in rep_mhz.per_level]
+        assert err_ghz and all(e is not None for e in err_ghz)
+        assert all(e is not None for e in err_mhz)
+        np.testing.assert_allclose(err_ghz, err_mhz, rtol=1e-9)
+        # the verdict must not depend on the unit system either
+        assert rep_ghz.aggregate_status == rep_mhz.aggregate_status
 
     def test_absolute_scope_without_target_returns_unverified(self):
         # The report still contains abs_err_est_GHz per level, but status

--- a/scqubits/tests/test_convergence.py
+++ b/scqubits/tests/test_convergence.py
@@ -244,6 +244,41 @@ class TestEnergyModerateMode:
         # the verdict must not depend on the unit system either
         assert rep_ghz.aggregate_status == rep_mhz.aggregate_status
 
+    def test_eps_gap_is_unit_invariant_when_floor_binds(self):
+        # observed-gap-scale eps = err / gap, with a large g_floor_GHz that floors
+        # the isolation gap. The GHz floor must be rescaled into the active units
+        # so eps stays unit-invariant even when the floor binds (regression for
+        # the floor-rescaling raised in #316 review).
+        original_units = sq.get_units()
+        kw = dict(
+            n_levels=4,
+            mode="moderate",
+            scope="observed_gap_scale",
+            g_floor_GHz=10.0,
+            target_gap_rel=1e-3,
+        )
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                sq.set_units("GHz")
+                rep_ghz = sq.Transmon(
+                    EJ=15.0, EC=0.3, ng=0.0, ncut=5, truncated_dim=6
+                ).check_convergence(**kw)
+                sq.set_units("MHz")
+                rep_mhz = sq.Transmon(
+                    EJ=15000.0, EC=300.0, ng=0.0, ncut=5, truncated_dim=6
+                ).check_convergence(**kw)
+        finally:
+            sq.set_units(original_units)
+        eps_ghz = [
+            v.eps_gap_est for v in rep_ghz.per_level if v.eps_gap_est is not None
+        ]
+        eps_mhz = [
+            v.eps_gap_est for v in rep_mhz.per_level if v.eps_gap_est is not None
+        ]
+        assert eps_ghz
+        np.testing.assert_allclose(eps_ghz, eps_mhz, rtol=1e-9)
+
     def test_absolute_scope_without_target_returns_unverified(self):
         # The report still contains abs_err_est_GHz per level, but status
         # defaults to unverified when no target is supplied.


### PR DESCRIPTION
Addresses the `set_units()` concern from #306 (raised by @Harrinive) for the **energy-convergence** path.

## Problem
The energy diagnostics report absolute error estimates, isolation gaps, the `_GHz` thresholds, and the refinement noise floor in **GHz** — but eigenvalues come out of `eigensys()` in the **active** unit system and were used unconverted. So under `scq.set_units("MHz")` (or anything ≠ GHz):
- the reported `abs_err_est_GHz` scaled with the unit (≈1000× under MHz) — mislabeled, not actually GHz;
- worse, the per-cluster difference was compared against the hardcoded `_REFINEMENT_NOISE_FLOOR_GHz` (a GHz constant), so the **verdict** — not just the label — could flip.

The coherence path already does the right thing (normalizes rates to Hz via `units.units_scale_factor()`); the energy path didn't.

## Fix
Convert eigenvalues to GHz at the three `eigensys()` sites via a small `_evals_to_GHz()` helper (`× units_scale_factor()/1e9`; the identity under GHz). With eigenvalues canonicalized at the source, every downstream energy quantity — diffs, clustering, isolation gaps, the `_REFINEMENT_NOISE_FLOOR_GHz` comparison, and all reported `*_GHz` fields — is genuinely GHz under any unit system.

## Verification
Same physical transmon expressed in GHz (`EJ=15`) vs MHz (`EJ=15000`), under-converged so the error is real:

| mode | `abs_err_est_GHz` ratio MHz/GHz, before | after |
|---|---|---|
| moderate | ~1000× (bug) | **1.000** ✅ |
| strict | ~1000× (bug) | **1.000** ✅ |

Full convergence suite: **149 passed**, no regressions. Adds a regression test (`test_abs_err_estimate_is_unit_invariant`) asserting the moderate-mode estimate is unit-invariant — which would have caught this.

## Scope / not included
This fixes the **moderate/strict** energy paths. The **cheap-mode** perturbative tail estimate (the `U_N` quantity) is computed in each qubit's own `_convergence_tail_estimate` override and still operates in the active unit system — its ratio remains ~1000×. That's a separate, per-qubit change (and ties into #306's third point that `U_N` itself is undocumented), best done by whoever owns those formulas. Flagging rather than guessing at the tail-error unit scaling.

Targets `convergence/pr-7-multiaxis` (the latest convergence state; the module isn't in `main` yet).