### PR TITLE
docs(convergence): define U_N (the cluster subspace diagnostic) [#306]

### DIFF
--- a/scqubits/core/convergence.py
+++ b/scqubits/core/convergence.py
@@ -1474,9 +1474,11 @@ class ConvergenceCheckable:
         Both eigenvector sets are embedded into the larger basis via the
         qubit's :meth:`_convergence_pad_eigenvectors` hook. Isolated levels use
         the overlap deficit ``1 - |<a_k | b_k>|`` (invariant to each vector's
-        global phase); near-degenerate clusters use the subspace angle, assigned
-        to every member, which is robust to eigenvector rotations within the
-        block.
+        global phase); near-degenerate clusters use the subspace angle of the
+        cluster's eigenvector block ``U_N`` at the two cutoffs (the ``sin(Theta)``
+        diagnostic; see :func:`~scqubits.utils.convergence_utils.subspace_angle`),
+        assigned to every member, which is robust to eigenvector rotations within
+        the block.
         """
         value_max = max(value_a, value_b)
         a = self._convergence_pad_eigenvectors(

--- a/scqubits/utils/convergence_utils.py
+++ b/scqubits/utils/convergence_utils.py
@@ -587,20 +587,36 @@ def pad_charge_basis(
 def subspace_angle(
     subspace_a: npt.NDArray[np.float64], subspace_b: npt.NDArray[np.float64]
 ) -> float:
-    """Return the sine of the largest principal angle between two subspaces.
+    r"""Return the sine of the largest principal angle between two subspaces.
 
-    The subspaces are the column spans of ``subspace_a`` and ``subspace_b`` --
-    tall matrices with matching row dimension and orthonormal columns. The value
-    ``||(I - A A^H) B||_2`` is 0 when the spans coincide and 1 when ``B`` has a
-    direction orthogonal to all of ``A``. This is the cluster-level analogue of
-    one minus a wavefunction overlap, robust to eigenvector rotations within a
-    near-degenerate block.
+    This is the cluster-level convergence diagnostic written ``U_N`` in the design
+    notes. For a near-degenerate cluster, ``subspace_a`` and ``subspace_b`` are the
+    blocks of eigenvector columns spanning that cluster at two cutoffs -- i.e. the
+    relevant columns of the diagonalizing unitary (the cluster's ``U_N`` at cutoff
+    ``N``), orthonormal and embedded in a common basis. Individual eigenvectors
+    inside a (near-)degenerate block are not physically well-defined: they can
+    rotate arbitrarily among themselves between cutoffs, which would make a
+    vector-by-vector overlap spuriously report change. The diagnostic therefore
+    compares the *spans* of the blocks instead.
+
+    With ``A = subspace_a`` and ``B = subspace_b``, the returned value is
+
+        sin(Theta) = || (I - A A^H) B ||_2,
+
+    the sine of the largest principal angle between the two spans: ``0`` when the
+    spans coincide (the cluster's eigenspace did not move under refinement) and
+    ``1`` when ``B`` has a direction orthogonal to all of ``A``. It is the
+    cluster-level analogue of one minus a wavefunction overlap, invariant to any
+    unitary rotation of the eigenvectors within the block. Being built from
+    eigenvectors alone, it is dimensionless and independent of the active energy
+    unit (:func:`scqubits.set_units`).
 
     Parameters
     ----------
     subspace_a, subspace_b:
-        Tall matrices with the same number of rows and orthonormal columns; the
-        caller pads them to a common basis first if the cutoffs differ.
+        The cluster's eigenvector blocks at two cutoffs (orthonormal columns,
+        same number of rows); the caller pads them to a common basis first if the
+        cutoffs differ.
 
     Returns
     -------


### PR DESCRIPTION
Addresses point #3 of #306 (raised by @Harrinive): *"I am not sure how those `U_N` are defined."*

`U_N` is the cluster-level subspace convergence diagnostic. For a near-degenerate cluster, it is the block of **eigenvector** columns spanning that cluster (the relevant columns of the diagonalizing unitary), and the diagnostic is the sine of the largest principal angle between that block at two cutoffs:

```
sin(Theta) = || (I - A A^H) B ||_2
```

(0 = the cluster's eigenspace did not move under refinement; 1 = fully rotated out). It's the cluster-level analogue of one minus a wavefunction overlap, robust to the arbitrary rotation of individual eigenvectors within a degenerate block — and, being built from eigenvectors alone, **dimensionless and independent of `set_units`** (it is *not* one of the energy quantities addressed by the unit fix in #316).

## Changes (docs only)
- `convergence_utils.subspace_angle`: docstring now defines `U_N` (the cluster's eigenvector block at a cutoff), explains why spans rather than individual eigenvectors are compared, gives the formula and its 0..1 meaning, and notes the dimensionless/unit-independent nature.
- The wavefunction-channel call site (`_convergence_wavefunction_refinement_diff`) names `U_N` and cross-references `subspace_angle`.

No behavior change. `docstring_lint` clean, `black` clean, imports verified.

Targets `convergence/pr-7-multiaxis` (latest convergence state; the module isn't in `main` yet).