### PR TITLE
Coerce as_scipy() result back to csc_matrix for qutip >= 5.3.1

### DIFF
--- a/scqubits/utils/misc.py
+++ b/scqubits/utils/misc.py
@@ -226,11 +226,15 @@ def qt_ket_to_ndarray(qobj_ket: qt.Qobj) -> np.ndarray:
 
 
 def Qobj_to_scipy_csc_matrix(qobj_array: qt.Qobj) -> sp.sparse.csc_matrix:
-    return (
+    csc_data = (
         qobj_array.to("csr").data.as_scipy().tocsc()
         if qt.__version__ >= "5.0.0"
         else qobj_array.data.tocsc()
     )
+    # qutip >= 5.3.1 yields a sparse array here; callers expect csc_matrix
+    if not sp.sparse.isspmatrix(csc_data):
+        csc_data = sp.sparse.csc_matrix(csc_data)
+    return csc_data
 
 
 def get_shape(lst, shape=()):


### PR DESCRIPTION

Fixes #320.

qutip 5.3.1's `Data.as_scipy()` returns scipy sparse arrays, so `Qobj_to_scipy_csc_matrix` produced `csc_array` instead of `csc_matrix` and every `HilbertSpace` workflow raised `TypeError` in `convert_operator_to_qobj` (see issue for details).

**Change:** one guard in `Qobj_to_scipy_csc_matrix` — if the result is a sparse array, wrap it in `csc_matrix` (cheap; reuses the underlying buffers). Behavior under qutip ≤ 5.3.0 is unchanged. Teaching the dispatch to accept sparse arrays natively is left as a follow-up, since scipy is deprecating `spmatrix` long-term.

**Testing** (qutip 5.3.1, scipy 1.18.0, Python 3.12):
- `scqubits/tests/test_hilbertspace.py`: 11/19 fail on `main` → 19/19 pass with this patch.
- Downstream: [quchip](https://github.com/quchip/quchip)'s scqubits-oracle interop suite: 8/21 fail on `main` → 21/21 pass.

*Disclosure: investigated, implemented, and validated by Claude Fable; reviewed by me.*
